### PR TITLE
Don't close the DB connection after migrations.

### DIFF
--- a/server/database/migrations.go
+++ b/server/database/migrations.go
@@ -23,7 +23,6 @@ func RunMigrations(db *DB) error {
 	if err != nil {
 		return fmt.Errorf("could not create migrate instance: %w", err)
 	}
-	defer m.Close()
 
 	err = m.Up()
 	if err != nil && err != migrate.ErrNoChange {


### PR DESCRIPTION
I thought this would just clean up migrate's internal state, but it appears to close the db as well.