### PR TITLE
Make board mobile-friendly

### DIFF
--- a/web_client/src/components/GameBoard.css
+++ b/web_client/src/components/GameBoard.css
@@ -45,14 +45,32 @@
   justify-content: center;
   align-items: center;
   padding: 2rem 0;
+  width: 100%;
 }
 
-.board-canvas {
+.board-svg {
   cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 4px;
+  width: 100%;
+  max-width: 600px;
+  height: auto;
 }
 
-.board-canvas:hover {
+.board-svg:hover {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+@media (max-width: 768px) {
+  .game-header {
+    padding: 0 0.5rem;
+  }
+
+  .board-container {
+    padding: 0.5rem 0.25rem;
+  }
+
+  .board-svg {
+    max-width: 100%;
+  }
 }

--- a/web_client/src/components/GameBoard.tsx
+++ b/web_client/src/components/GameBoard.tsx
@@ -269,7 +269,7 @@ const GameBoard: React.FC<GameBoardProps> = ({ game }) => {
         </div>
       </div>
       <div className="board-container">
-        <svg width={svgSize} height={svgSize} className="board-svg">
+        <svg viewBox={`0 0 ${svgSize} ${svgSize}`} className="board-svg">
           <rect width={svgSize} height={svgSize} fill="#DEB887" />
           {renderGridLines()}
           {renderStarPoints()}

--- a/web_client/src/components/Layout.css
+++ b/web_client/src/components/Layout.css
@@ -196,6 +196,6 @@
   }
 
   .layout-main {
-    padding: 1rem;
+    padding: 0.5rem;
   }
 }

--- a/web_client/src/pages/GamePage.css
+++ b/web_client/src/pages/GamePage.css
@@ -73,13 +73,14 @@
 
 @media (max-width: 768px) {
   .game-page {
-    padding: 0.5rem;
+    padding: 0;
   }
 
   .game-page-header {
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
+    padding: 0.5rem 1rem;
   }
 
   .game-meta h2 {
@@ -88,5 +89,6 @@
 
   .game-board-container {
     min-height: 400px;
+    padding: 0;
   }
 }


### PR DESCRIPTION
Allow board and padding to resize for small screens

<img width="2880" height="3200" alt="boardlayoutdiff" src="https://github.com/user-attachments/assets/538d904c-45b2-4f7e-88da-f4645eb571f3" />