### PR TITLE
Add just for easier development

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,22 @@ frogs_cafe/
 - PostgreSQL 15 or later (or use Docker)
 - Node.js 16 or later (for frontend)
 - Docker (with Docker Compose V2 plugin) - optional, for containerized development
+- [just](https://github.com/casey/just) - optional, command runner for easier workflows
+- [tmux](https://github.com/tmux/tmux/wiki/Installing) - optional, for split-screen development with `just run`
 
 ## Getting Started
 
 ### Development Mode (Recommended)
 
-**Best for active development with hot-reload:**
+Installing dependencies and running the frontend and backend servers with hot reload is easy, using [just](https://github.com/casey/just).
 
-1. **Start backend services with Docker:**
-   ```bash
-   docker compose -f docker-compose.dev.yml up
-   ```
-   This starts PostgreSQL and the Go server on `localhost:8080`
+```bash
+# First time setup - install dependencies
+just install
 
-2. **Run React dev server locally:**
-   ```bash
-   cd web_client
-   npm install
-   npm run dev
-   ```
-   Frontend runs on `localhost:3000` with hot-reload. API calls are automatically proxied to the backend.
+# Run both server and client
+just run
+```
 
 ### Production Mode
 
@@ -62,6 +58,9 @@ docker compose up --build
 This builds the React app into static files and serves them from the Go server at `localhost:8080`
 
 ### Manual Setup (No Docker)
+
+If you don't want to install tools like just, Docker or tmux, the bare minimum dependencies are
+the Go and Node toolchains and Postgres.  You can run them directly, like so.
 
 1. **Set up PostgreSQL**:
    ```bash

--- a/justfile
+++ b/justfile
@@ -1,0 +1,34 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+server_cmd := "docker compose -f docker-compose.dev.yml up"
+client_cmd := "cd web_client && npm run dev"
+
+_default:
+	@just --list
+
+# Install all dependencies (Go modules and npm packages)
+install:
+	cd server && go mod download
+	cd web_client && npm install
+
+# Run server and client in split tmux session with hot reload
+run:
+	#!/usr/bin/env bash
+	if ! command -v tmux >/dev/null 2>&1; then
+	    echo "tmux is not installed."
+	    echo "Install instructions: https://github.com/tmux/tmux/wiki/Installing"
+	    echo "Or run the services separately:"
+	    echo "  {{ server_cmd }}"
+	    echo "  {{ client_cmd }}"
+	    exit 1
+	fi
+	
+	session="frogs_cafe_dev"
+	if tmux has-session -t "$session" 2>/dev/null; then
+	    tmux kill-session -t "$session"
+	fi
+	
+	tmux new-session -d -s "$session" "{{ server_cmd }}"
+	tmux split-window -h -t "$session" "{{ client_cmd }}"
+	tmux select-layout -t "$session" even-horizontal
+	tmux attach -t "$session"


### PR DESCRIPTION
My workflow until now was to open two terminals manually and run the npm/docker commands.  We can simplify this using `just` command runner. 

# Sad path (tmux not installed)

```
% just run
tmux is not installed.
Install instructions: https://github.com/tmux/tmux/wiki/Installing
Or run the services separately:
  docker compose -f docker-compose.dev.yml up
  cd web_client && npm run dev
```

# Happy path (servers are launched in split panels)

```
frogs_cafe_server  | 2026/01/03 18:03:32 [OK] .env f│> frogs-cafe-frontend@0.1.0 dev
ile loaded successfully                             │> vite
                                                    │
frogs_cafe_server  | 2026/01/03 18:03:32            │The CJS build of Vite's Node API is deprecated. See
                                                    │ https://vite.dev/guide/troubleshooting.html#vite-c
frogs_cafe_server  | Loading configuration...       │js-node-api-deprecated for more details.
                                                    │
frogs_cafe_server  | 2026/01/03 18:03:32 Configurati│  VITE v5.4.21  ready in 219 ms
on loaded - running in development mode             │
                                                    │  ➜  Local:   http://localhost:3000/
frogs_cafe_server  | 2026/01/03 18:03:32 Current mig│  ➜  Network: use --host to expose
ration version: 6 (dirty: false)                    │  ➜  press h + enter to show help
                                                    │
frogs_cafe_server  | 2026/01/03 18:03:32 Starting se│
rver on port 8080                                   │
                                                    │
                                                    │
[frogs_caf0:node*                                                         "Mac-3449.lan" 13:03 03-Jan-26
```