### PR TITLE
Add BIK (Baduk InterKonnect) federation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A WebSocket-enabled Go (Baduk/Weiqi) game server built with Go and PostgreSQL, featuring a React frontend.
 
+## Federation (BIK)
+
+Frogs Café implements **BIK (Baduk InterKonnect)**, a protocol for playing Go across servers — so a player on frogs.cafe can play against a player on any other BIK-compatible server.
+
+If you want to implement BIK on your own server:
+
+1. **Read the spec** — [`bik/spec/protocol.md`](bik/spec/protocol.md)
+2. **Consume the types** — [`bik/bik-js/`](bik/bik-js/) is a TypeScript library with types, AP activity builders, and a WebSocket client
+3. **Implement** — the five server-side endpoints you need are documented in the spec; frogs.cafe's Go implementation is in [`server/handlers/bik.go`](server/handlers/bik.go) if you want a reference
+
+To run the E2E test (two servers, two databases, full federation flow):
+```bash
+just e2e
+```
+
 ## Project Structure
 
 ```

--- a/bik/bik-js/.gitignore
+++ b/bik/bik-js/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/bik/bik-js/README.md
+++ b/bik/bik-js/README.md
@@ -91,6 +91,81 @@ client.send({ type: "score_accept", data: {} });
 client.send({ type: "score_reject", data: {} });
 ```
 
+## Matchmaking (ActivityPub)
+
+BIK uses ActivityPub for challenge advertisement and acceptance. Use the activity builders to construct valid AP payloads, then POST them to the target server's inbox.
+
+### Advertising a challenge
+
+```ts
+import { buildCreateChallenge, postActivity } from "bik-js";
+
+const activity = buildCreateChallenge(
+  "https://frogs.cafe/users/alice",           // your actor URI
+  "https://frogs.cafe/challenges/abc123",     // challenge URI (you mint this)
+  {
+    type: "BikChallenge",
+    boardSize: 19,
+    timeControl: { system: "byoyomi", mainTime: 600, periods: 5, periodTime: 30 },
+    colorPreference: "any",
+    expiresAt: "2024-03-10T15:30:00Z",
+  },
+  "Looking for a game! 19x19, 10min + 5x30s byo-yomi",
+);
+
+// Broadcast to your followers / federate as needed
+```
+
+### Accepting a challenge
+
+```ts
+import { buildAcceptChallenge, postActivity } from "bik-js";
+
+const activity = buildAcceptChallenge(
+  "https://server-b.example/users/bob",       // your actor URI
+  "https://server-a.example/challenges/abc123", // URI of the challenge
+);
+
+await postActivity("https://server-a.example/inbox", activity);
+// Server A responds with a CreateGame activity containing the WebSocket URL
+```
+
+### Withdrawing a challenge
+
+When a challenge is accepted or cancelled, the host sends an `Undo` so other servers can remove it from open challenge lists.
+
+```ts
+import { buildUndoChallenge, postActivity } from "bik-js";
+
+const activity = buildUndoChallenge(
+  "https://server-a.example/users/alice",
+  "https://server-a.example/challenges/abc123",
+);
+
+// Broadcast to followers
+```
+
+### Announcing a game result
+
+```ts
+import { buildCreateGameResult, postActivity } from "bik-js";
+
+const activity = buildCreateGameResult(
+  "https://server-a.example/users/alice",
+  "https://server-a.example/games/xyz789/result",
+  "https://server-a.example/games/xyz789",
+  {
+    type: "BikGameResult",
+    winner: "https://server-a.example/users/alice",
+    result: "B+R",
+    sgf: "https://server-a.example/games/xyz789.sgf",
+  },
+  "@alice (B) defeated @bob@server-b.example (W) by resignation.",
+);
+```
+
+Results are standard AP `Note` objects and will appear as posts on Mastodon and other ActivityPub clients.
+
 ## Types
 
 All types are exported from the package root:

--- a/bik/bik-js/README.md
+++ b/bik/bik-js/README.md
@@ -107,7 +107,7 @@ const activity = buildCreateChallenge(
     type: "BikChallenge",
     boardSize: 19,
     timeControl: { system: "byoyomi", mainTime: 600, periods: 5, periodTime: 30 },
-    colorPreference: "any",
+    colorAssignment: "random",
     expiresAt: "2024-03-10T15:30:00Z",
   },
   "Looking for a game! 19x19, 10min + 5x30s byo-yomi",

--- a/bik/bik-js/README.md
+++ b/bik/bik-js/README.md
@@ -1,0 +1,133 @@
+# bik-js
+
+TypeScript client library for the [BIK (Baduk InterKonnect)](../spec/protocol.md) protocol.
+
+## Install
+
+```bash
+npm install bik-js
+```
+
+For Node.js environments, also install the `ws` package:
+
+```bash
+npm install ws
+```
+
+## Usage
+
+### Connecting to a game
+
+```ts
+import { BikClient } from "bik-js";
+
+const client = new BikClient(
+  "wss://server-a.example/ws/games/xyz789", // from the BikGame AP activity
+  "<token>",                                 // issued by your home server
+);
+
+client.connect();
+```
+
+In Node.js, pass the `ws` WebSocket implementation:
+
+```ts
+import { WebSocket } from "ws";
+
+const client = new BikClient(url, token, { WebSocketImpl: WebSocket });
+client.connect();
+```
+
+### Playing a game
+
+```ts
+const client = new BikClient(url, token, {
+  onReady(msg) {
+    // msg.type === "game_state" — received on connect
+    console.log("game ready, moves so far:", msg.data.moves);
+  },
+  onMessage(msg) {
+    switch (msg.type) {
+      case "move_played":
+        console.log(`${msg.data.color} played ${msg.data.pos}, move #${msg.data.moveNumber}`);
+        break;
+      case "move_rejected":
+        console.warn("move rejected:", msg.data.reason);
+        break;
+      case "clock":
+        console.log("clock update:", msg.data);
+        break;
+      case "game_over":
+        console.log("result:", msg.data.result);
+        break;
+    }
+  },
+});
+
+client.connect();
+
+// Place a stone at col 3, row 3
+client.send({ type: "move", data: { pos: [3, 3] } });
+
+// Pass
+client.send({ type: "move", data: { pos: null } });
+
+// Resign
+client.send({ type: "resign", data: {} });
+```
+
+### Scoring phase
+
+When both players pass, the server sends `{ type: "phase_change", data: { phase: "scoring" } }`.
+
+```ts
+// Mark groups as dead
+client.send({ type: "mark_dead", data: { positions: [[3, 3], [4, 3]] } });
+
+// Accept the score
+client.send({ type: "score_accept", data: {} });
+
+// Reject and resume play
+client.send({ type: "score_reject", data: {} });
+```
+
+## Types
+
+All types are exported from the package root:
+
+```ts
+import type {
+  // Common
+  Position, Color, Clock, GamePhase, GameResult, TimeControl,
+
+  // WebSocket messages
+  ClientMessage, ServerMessage,
+  MovePlayed, MoveRejectedReason, GameStateData,
+
+  // ActivityPub activities
+  BikChallenge, BikGame, BikGameResult,
+  CreateChallengeActivity, AcceptChallengeActivity,
+  UndoChallengeActivity, CreateGameActivity, CreateGameResultActivity,
+} from "bik-js";
+```
+
+### Coordinates
+
+Positions are `[col, row]` zero-indexed integer arrays. `[0, 0]` is the top-left corner. Pass is `null`.
+
+```ts
+const d4: Position = [3, 3];
+const pass: Position = null;
+```
+
+### Clock
+
+Clocks are discriminated by `system`:
+
+```ts
+if (clock.system === "byoyomi") {
+  console.log(clock.black.periods, "periods remaining");
+} else if (clock.system === "fischer") {
+  console.log("increment:", clock.increment);
+}
+```

--- a/bik/bik-js/package-lock.json
+++ b/bik/bik-js/package-lock.json
@@ -1,0 +1,1558 @@
+{
+  "name": "bik-js",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bik-js",
+      "version": "0.1.0",
+      "dependencies": {
+        "jose": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/ws": "^8.5.0",
+        "ajv": "^8.17.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/bik/bik-js/package-lock.json
+++ b/bik/bik-js/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@types/ws": "^8.5.0",
         "ajv": "^8.17.0",
+        "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "vitest": "^2.0.0",
         "ws": "^8.18.0"
@@ -307,6 +308,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -324,6 +342,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -339,6 +374,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1103,6 +1155,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/jose": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
@@ -1225,6 +1290,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1343,6 +1418,459 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/typescript": {

--- a/bik/bik-js/package.json
+++ b/bik/bik-js/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bik-js",
+  "version": "0.1.0",
+  "description": "Baduk InterKonnect protocol library",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "jose": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.0",
+    "ajv": "^8.17.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/bik/bik-js/package.json
+++ b/bik/bik-js/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/ws": "^8.5.0",
     "ajv": "^8.17.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0",
     "ws": "^8.18.0"

--- a/bik/bik-js/src/ap.ts
+++ b/bik/bik-js/src/ap.ts
@@ -1,0 +1,79 @@
+import type {
+  BikChallenge,
+  BikGame,
+  BikGameResult,
+  CreateChallengeActivity,
+  AcceptChallengeActivity,
+  UndoChallengeActivity,
+  CreateGameActivity,
+  CreateGameResultActivity,
+} from "./types/ap.js";
+
+const CONTEXT = "https://www.w3.org/ns/activitystreams" as const;
+
+export function buildCreateChallenge(
+  actor: string,
+  id: string,
+  challenge: BikChallenge,
+  content: string,
+): CreateChallengeActivity {
+  return {
+    "@context": CONTEXT,
+    type: "Create",
+    actor,
+    object: { type: "Note", id, attributedTo: actor, content, attachment: challenge },
+  };
+}
+
+export function buildAcceptChallenge(
+  actor: string,
+  challengeUri: string,
+): AcceptChallengeActivity {
+  return { "@context": CONTEXT, type: "Accept", actor, object: challengeUri };
+}
+
+export function buildUndoChallenge(
+  actor: string,
+  challengeUri: string,
+): UndoChallengeActivity {
+  return { "@context": CONTEXT, type: "Undo", actor, object: challengeUri };
+}
+
+export function buildCreateGame(
+  actor: string,
+  id: string,
+  challengeUri: string,
+  game: BikGame,
+  content: string,
+): CreateGameActivity {
+  return {
+    "@context": CONTEXT,
+    type: "Create",
+    actor,
+    object: { type: "Note", id, content, inReplyTo: challengeUri, attachment: game },
+  };
+}
+
+export function buildCreateGameResult(
+  actor: string,
+  id: string,
+  gameUri: string,
+  result: BikGameResult,
+  content: string,
+): CreateGameResultActivity {
+  return {
+    "@context": CONTEXT,
+    type: "Create",
+    actor,
+    object: { type: "Note", id, content, inReplyTo: gameUri, attachment: result },
+  };
+}
+
+/** POST an AP activity to a remote inbox */
+export async function postActivity(inboxUrl: string, activity: object): Promise<Response> {
+  return fetch(inboxUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/activity+json" },
+    body: JSON.stringify(activity),
+  });
+}

--- a/bik/bik-js/src/client.ts
+++ b/bik/bik-js/src/client.ts
@@ -1,0 +1,59 @@
+import type { ClientMessage, ServerMessage } from "./types/ws.js";
+
+export type MessageHandler = (msg: ServerMessage) => void;
+
+export interface BikClientOptions {
+  /** Called when the connection is established and game_state is received */
+  onReady?: MessageHandler;
+  onMessage?: MessageHandler;
+  onClose?: () => void;
+  onError?: (err: Event) => void;
+  /** Provide a WebSocket constructor for Node.js environments (e.g. from 'ws') */
+  WebSocketImpl?: typeof WebSocket;
+}
+
+export class BikClient {
+  private ws: WebSocket | null = null;
+  private url: string;
+  private token: string;
+  private opts: BikClientOptions;
+
+  constructor(url: string, token: string, opts: BikClientOptions = {}) {
+    this.url = url;
+    this.token = token;
+    this.opts = opts;
+  }
+
+  connect(): void {
+    const WS = this.opts.WebSocketImpl ?? WebSocket;
+    const fullUrl = `${this.url}?token=${encodeURIComponent(this.token)}`;
+    this.ws = new WS(fullUrl) as WebSocket;
+
+    this.ws.onmessage = (event) => {
+      let msg: ServerMessage;
+      try {
+        msg = JSON.parse(event.data as string) as ServerMessage;
+      } catch {
+        return;
+      }
+      if (msg.type === "game_state") {
+        this.opts.onReady?.(msg);
+      }
+      this.opts.onMessage?.(msg);
+    };
+
+    this.ws.onclose = () => this.opts.onClose?.();
+    this.ws.onerror = (err) => this.opts.onError?.(err);
+  }
+
+  send(msg: ClientMessage): void {
+    if (!this.ws || this.ws.readyState !== this.ws.OPEN) {
+      throw new Error("BikClient: not connected");
+    }
+    this.ws.send(JSON.stringify(msg));
+  }
+
+  close(): void {
+    this.ws?.close();
+  }
+}

--- a/bik/bik-js/src/index.ts
+++ b/bik/bik-js/src/index.ts
@@ -1,0 +1,13 @@
+export * from "./types/common.js";
+export * from "./types/ws.js";
+export * from "./types/ap.js";
+export { BikClient } from "./client.js";
+export type { BikClientOptions } from "./client.js";
+export {
+  buildCreateChallenge,
+  buildAcceptChallenge,
+  buildUndoChallenge,
+  buildCreateGame,
+  buildCreateGameResult,
+  postActivity,
+} from "./ap.js";

--- a/bik/bik-js/src/types/ap.ts
+++ b/bik/bik-js/src/types/ap.ts
@@ -4,16 +4,17 @@ export interface BikChallenge {
   type: "BikChallenge";
   boardSize: number;
   timeControl: TimeControl;
-  colorPreference: "black" | "white" | "any";
+  colorAssignment: "black" | "white" | "random";
+  komi?: number;     // default 0
   expiresAt: string; // ISO 8601
 }
 
 export interface BikGame {
   type: "BikGame";
-  id: string;
+  id: string;        // full game URI (human-readable page)
   black: string;     // actor URI
   white: string;     // actor URI
-  url: string;       // human-readable game page
+  komi?: number;     // default 0
   websocket: string; // wss:// URL
 }
 
@@ -28,6 +29,8 @@ export interface CreateChallengeActivity {
   "@context": "https://www.w3.org/ns/activitystreams";
   type: "Create";
   actor: string;
+  to: string[];
+  cc: string[];
   object: {
     type: "Note";
     id: string;
@@ -41,6 +44,7 @@ export interface AcceptChallengeActivity {
   "@context": "https://www.w3.org/ns/activitystreams";
   type: "Accept";
   actor: string;
+  to: string[];  // [challenger actor URI]
   object: string; // URI of the challenge Note
 }
 
@@ -48,6 +52,8 @@ export interface UndoChallengeActivity {
   "@context": "https://www.w3.org/ns/activitystreams";
   type: "Undo";
   actor: string;
+  to: string[];
+  cc: string[];
   object: string; // URI of the challenge Note
 }
 
@@ -55,6 +61,8 @@ export interface CreateGameActivity {
   "@context": "https://www.w3.org/ns/activitystreams";
   type: "Create";
   actor: string;
+  to: string[];
+  cc: string[];  // includes both players and host's followers
   object: {
     type: "Note";
     id: string;
@@ -68,6 +76,8 @@ export interface CreateGameResultActivity {
   "@context": "https://www.w3.org/ns/activitystreams";
   type: "Create";
   actor: string;
+  to: string[];
+  cc: string[];  // includes both players and host's followers
   object: {
     type: "Note";
     id: string;

--- a/bik/bik-js/src/types/ap.ts
+++ b/bik/bik-js/src/types/ap.ts
@@ -1,0 +1,78 @@
+import type { GameResult, TimeControl } from "./common.js";
+
+export interface BikChallenge {
+  type: "BikChallenge";
+  boardSize: number;
+  timeControl: TimeControl;
+  colorPreference: "black" | "white" | "any";
+  expiresAt: string; // ISO 8601
+}
+
+export interface BikGame {
+  type: "BikGame";
+  id: string;
+  black: string;     // actor URI
+  white: string;     // actor URI
+  url: string;       // human-readable game page
+  websocket: string; // wss:// URL
+}
+
+export interface BikGameResult {
+  type: "BikGameResult";
+  winner: string;    // actor URI
+  result: GameResult;
+  sgf?: string;      // URI
+}
+
+export interface CreateChallengeActivity {
+  "@context": "https://www.w3.org/ns/activitystreams";
+  type: "Create";
+  actor: string;
+  object: {
+    type: "Note";
+    id: string;
+    attributedTo: string;
+    content: string;
+    attachment: BikChallenge;
+  };
+}
+
+export interface AcceptChallengeActivity {
+  "@context": "https://www.w3.org/ns/activitystreams";
+  type: "Accept";
+  actor: string;
+  object: string; // URI of the challenge Note
+}
+
+export interface UndoChallengeActivity {
+  "@context": "https://www.w3.org/ns/activitystreams";
+  type: "Undo";
+  actor: string;
+  object: string; // URI of the challenge Note
+}
+
+export interface CreateGameActivity {
+  "@context": "https://www.w3.org/ns/activitystreams";
+  type: "Create";
+  actor: string;
+  object: {
+    type: "Note";
+    id: string;
+    content: string;
+    inReplyTo: string;
+    attachment: BikGame;
+  };
+}
+
+export interface CreateGameResultActivity {
+  "@context": "https://www.w3.org/ns/activitystreams";
+  type: "Create";
+  actor: string;
+  object: {
+    type: "Note";
+    id: string;
+    content: string;
+    inReplyTo: string;
+    attachment: BikGameResult;
+  };
+}

--- a/bik/bik-js/src/types/common.ts
+++ b/bik/bik-js/src/types/common.ts
@@ -1,0 +1,24 @@
+export type Position = [number, number] | null;
+
+export type Color = "black" | "white";
+
+export type GamePhase = "active" | "scoring" | "finished";
+
+/** SGF-style result: B+R, W+3.5, B+T, etc. */
+export type GameResult = string;
+
+export interface ByoyomiPlayerClock {
+  main: number;       // seconds remaining
+  periods: number;
+  periodTime: number; // seconds per period
+}
+
+export type Clock =
+  | { system: "byoyomi"; black: ByoyomiPlayerClock; white: ByoyomiPlayerClock; activeColor: Color }
+  | { system: "fischer"; black: number; white: number; increment: number; activeColor: Color }
+  | { system: "absolute"; black: number; white: number; activeColor: Color };
+
+export type TimeControl =
+  | { system: "byoyomi"; mainTime: number; periods: number; periodTime: number }
+  | { system: "fischer"; mainTime: number; increment: number }
+  | { system: "absolute"; mainTime: number };

--- a/bik/bik-js/src/types/ws.ts
+++ b/bik/bik-js/src/types/ws.ts
@@ -1,0 +1,44 @@
+import type { Position, Color, Clock, GamePhase, GameResult } from "./common.js";
+
+// ---- Client → Host ----
+
+export type ClientMessage =
+  | { type: "move";         data: { pos: Position } }
+  | { type: "resign";       data: Record<string, never> }
+  | { type: "mark_dead";    data: { positions: Position[] } }
+  | { type: "score_accept"; data: Record<string, never> }
+  | { type: "score_reject"; data: Record<string, never> };
+
+// ---- Host → Clients ----
+
+export interface GameStateData {
+  moves: Position[];
+  phase: GamePhase;
+  nextToPlay: Color;
+  clock: Clock;
+}
+
+export interface MovePlayed {
+  pos: Position;
+  moveNumber: number;
+  color: Color;
+  captures: Position[];
+  nextToPlay: Color;
+  clock: Clock;
+}
+
+export type MoveRejectedReason =
+  | "ko"
+  | "occupied"
+  | "suicide"
+  | "not_your_turn"
+  | "game_not_active";
+
+export type ServerMessage =
+  | { type: "game_state";   data: GameStateData }
+  | { type: "move_played";  data: MovePlayed }
+  | { type: "move_rejected"; data: { reason: MoveRejectedReason } }
+  | { type: "clock";        data: Clock }
+  | { type: "phase_change"; data: { phase: GamePhase } }
+  | { type: "dead_stones";  data: { positions: Position[] } }
+  | { type: "game_over";    data: { result: GameResult; winner: Color; scoreBlack: number | null; scoreWhite: number | null } };

--- a/bik/bik-js/test/ap.test.ts
+++ b/bik/bik-js/test/ap.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as http from "http";
+import {
+  buildCreateChallenge,
+  buildAcceptChallenge,
+  buildUndoChallenge,
+  buildCreateGame,
+  buildCreateGameResult,
+  postActivity,
+} from "../src/ap.js";
+import type { CreateChallengeActivity, AcceptChallengeActivity, UndoChallengeActivity, CreateGameActivity } from "../src/types/ap.js";
+
+const SERVER_A = "https://server-a.example";
+const SERVER_B = "https://server-b.example";
+const ALICE = `${SERVER_A}/users/alice`;
+const BOB = `${SERVER_B}/users/bob`;
+const CHALLENGE_URI = `${SERVER_A}/challenges/abc123`;
+const GAME_URI = `${SERVER_A}/games/xyz789`;
+
+const inbox = (port: number) => `http://localhost:${port}/inbox`;
+
+/** Simple mock HTTP inbox that records received activities */
+async function startInbox(port: number, respondWith: (activity: object) => object) {
+  const received: object[] = [];
+
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      const activity = JSON.parse(body) as object;
+      received.push(activity);
+      const reply = respondWith(activity);
+      res.writeHead(200, { "Content-Type": "application/activity+json" });
+      res.end(JSON.stringify(reply));
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(port, resolve));
+  return { server, received };
+}
+
+describe("AP activity builders", () => {
+  it("builds a valid CreateChallenge activity", () => {
+    const activity = buildCreateChallenge(
+      ALICE,
+      CHALLENGE_URI,
+      {
+        type: "BikChallenge",
+        boardSize: 19,
+        timeControl: { system: "byoyomi", mainTime: 600, periods: 5, periodTime: 30 },
+        colorPreference: "any",
+        expiresAt: "2024-03-10T15:30:00Z",
+      },
+      "Looking for a game! 19x19, 10min + 5x30s byo-yomi",
+    );
+
+    expect(activity["@context"]).toBe("https://www.w3.org/ns/activitystreams");
+    expect(activity.type).toBe("Create");
+    expect(activity.actor).toBe(ALICE);
+    expect(activity.object.attachment.type).toBe("BikChallenge");
+    expect(activity.object.attachment.boardSize).toBe(19);
+  });
+
+  it("builds a valid AcceptChallenge activity", () => {
+    const activity = buildAcceptChallenge(BOB, CHALLENGE_URI);
+    expect(activity.type).toBe("Accept");
+    expect(activity.actor).toBe(BOB);
+    expect(activity.object).toBe(CHALLENGE_URI);
+  });
+
+  it("builds a valid UndoChallenge activity", () => {
+    const activity = buildUndoChallenge(ALICE, CHALLENGE_URI);
+    expect(activity.type).toBe("Undo");
+    expect(activity.object).toBe(CHALLENGE_URI);
+  });
+});
+
+describe("challenge/accept flow", () => {
+  async function withInbox(port: number, respondWith: (activity: object) => object) {
+    const srv = await startInbox(port, respondWith);
+    return {
+      ...srv,
+      url: inbox(port),
+      [Symbol.asyncDispose]: async () => {
+        srv.server.closeAllConnections();
+        await new Promise<void>((resolve) => srv.server.close(() => resolve()));
+      },
+    };
+  }
+
+  it("server B accepts a challenge and server A creates the game", async () => {
+    await using srv = await withInbox(9878, () =>
+      buildCreateGame(
+        ALICE, GAME_URI, CHALLENGE_URI,
+        { type: "BikGame", id: "xyz789", black: ALICE, white: BOB,
+          url: `${SERVER_A}/games/xyz789`, websocket: `wss://server-a.example/ws/games/xyz789` },
+        "@alice vs @bob@server-b.example — Game started!",
+      ),
+    );
+
+    const accept = buildAcceptChallenge(BOB, CHALLENGE_URI);
+    const res = await postActivity(srv.url, accept);
+    const game = await res.json() as CreateGameActivity;
+
+    expect(res.status).toBe(200);
+    expect(game.type).toBe("Create");
+    expect(game.object.attachment.type).toBe("BikGame");
+    expect(game.object.attachment.websocket).toBe("wss://server-a.example/ws/games/xyz789");
+    expect(game.object.attachment.black).toBe(ALICE);
+    expect(game.object.attachment.white).toBe(BOB);
+
+    expect(srv.received).toHaveLength(1);
+    const received = srv.received[0] as AcceptChallengeActivity;
+    expect(received.type).toBe("Accept");
+    expect(received.object).toBe(CHALLENGE_URI);
+  });
+
+  it("server A withdraws the challenge after it is accepted", async () => {
+    const activities: object[] = [];
+    await using srv = await withInbox(9879, (a) => { activities.push(a); return { ok: true }; });
+
+    await postActivity(srv.url, buildAcceptChallenge(BOB, CHALLENGE_URI));
+    await postActivity(srv.url, buildUndoChallenge(ALICE, CHALLENGE_URI));
+
+    expect(activities).toHaveLength(2);
+    expect((activities[0] as AcceptChallengeActivity).type).toBe("Accept");
+    expect((activities[1] as UndoChallengeActivity).type).toBe("Undo");
+    expect((activities[1] as UndoChallengeActivity).object).toBe(CHALLENGE_URI);
+  });
+
+  it("server A announces the game result", async () => {
+    await using srv = await withInbox(9880, () => ({ ok: true }));
+
+    const result = buildCreateGameResult(
+      ALICE, `${GAME_URI}/result`, GAME_URI,
+      { type: "BikGameResult", winner: ALICE, result: "B+R", sgf: `${GAME_URI}.sgf` },
+      "@alice (B) defeated @bob@server-b.example (W) by resignation.",
+    );
+    const res = await postActivity(srv.url, result);
+
+    expect(res.status).toBe(200);
+    const received = srv.received[0] as CreateGameActivity;
+    expect(received.object.attachment.type).toBe("BikGameResult");
+    expect((received.object.attachment as { result: string }).result).toBe("B+R");
+  });
+});

--- a/bik/bik-js/test/ap.test.ts
+++ b/bik/bik-js/test/ap.test.ts
@@ -48,7 +48,7 @@ describe("AP activity builders", () => {
         type: "BikChallenge",
         boardSize: 19,
         timeControl: { system: "byoyomi", mainTime: 600, periods: 5, periodTime: 30 },
-        colorPreference: "any",
+        colorAssignment: "random",
         expiresAt: "2024-03-10T15:30:00Z",
       },
       "Looking for a game! 19x19, 10min + 5x30s byo-yomi",
@@ -92,8 +92,8 @@ describe("challenge/accept flow", () => {
     await using srv = await withInbox(9878, () =>
       buildCreateGame(
         ALICE, GAME_URI, CHALLENGE_URI,
-        { type: "BikGame", id: "xyz789", black: ALICE, white: BOB,
-          url: `${SERVER_A}/games/xyz789`, websocket: `wss://server-a.example/ws/games/xyz789` },
+        { type: "BikGame", id: GAME_URI, black: ALICE, white: BOB,
+          websocket: `wss://server-a.example/ws/games/xyz789` },
         "@alice vs @bob@server-b.example — Game started!",
       ),
     );

--- a/bik/bik-js/test/client.test.ts
+++ b/bik/bik-js/test/client.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { WebSocketServer, WebSocket as WS } from "ws";
+import { BikClient } from "../src/client.js";
+import type { ServerMessage, ClientMessage } from "../src/types/ws.js";
+
+const PORT = 9876;
+const GAME_URL = `ws://localhost:${PORT}`;
+const TOKEN = "test-token";
+
+function mockServer(): {
+  wss: WebSocketServer;
+  send: (msg: ServerMessage) => void;
+  received: ClientMessage[];
+  waitForMessage: () => Promise<ClientMessage>;
+} {
+  const wss = new WebSocketServer({ port: PORT });
+  const received: ClientMessage[] = [];
+  let conn: WS | null = null;
+  const pending: Array<(msg: ClientMessage) => void> = [];
+
+  wss.on("connection", (ws) => {
+    conn = ws;
+
+    // Send game_state on connect
+    const gameState: ServerMessage = {
+      type: "game_state",
+      data: {
+        moves: [],
+        phase: "active",
+        nextToPlay: "black",
+        clock: { system: "absolute", black: 600, white: 600, activeColor: "black" },
+      },
+    };
+    ws.send(JSON.stringify(gameState));
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString()) as ClientMessage;
+      received.push(msg);
+      pending.shift()?.(msg);
+    });
+  });
+
+  return {
+    wss,
+    send: (msg) => conn?.send(JSON.stringify(msg)),
+    received,
+    waitForMessage: () =>
+      new Promise((resolve) => pending.push(resolve)),
+  };
+}
+
+describe("BikClient", () => {
+  let server: ReturnType<typeof mockServer>;
+
+  beforeEach(() => {
+    server = mockServer();
+  });
+
+  afterEach(() => {
+    server.wss.close();
+  });
+
+  it("connects and receives game_state", async () => {
+    const messages: ServerMessage[] = [];
+    const client = new BikClient(GAME_URL, TOKEN, {
+      onMessage: (msg) => messages.push(msg),
+      WebSocketImpl: WS as unknown as typeof WebSocket,
+    });
+
+    client.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(messages[0].type).toBe("game_state");
+    client.close();
+  });
+
+  it("sends a move", async () => {
+    const client = new BikClient(GAME_URL, TOKEN, {
+      WebSocketImpl: WS as unknown as typeof WebSocket,
+    });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    client.send({ type: "move", data: { pos: [3, 3] } });
+    const received = await server.waitForMessage();
+
+    expect(received).toEqual({ type: "move", data: { pos: [3, 3] } });
+    client.close();
+  });
+
+  it("sends a pass", async () => {
+    const client = new BikClient(GAME_URL, TOKEN, {
+      WebSocketImpl: WS as unknown as typeof WebSocket,
+    });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    client.send({ type: "move", data: { pos: null } });
+    const received = await server.waitForMessage();
+
+    expect(received).toEqual({ type: "move", data: { pos: null } });
+    client.close();
+  });
+
+  it("receives move_played and updates state", async () => {
+    const messages: ServerMessage[] = [];
+    const client = new BikClient(GAME_URL, TOKEN, {
+      onMessage: (msg) => messages.push(msg),
+      WebSocketImpl: WS as unknown as typeof WebSocket,
+    });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    server.send({
+      type: "move_played",
+      data: {
+        pos: [3, 3],
+        moveNumber: 1,
+        color: "black",
+        captures: [],
+        nextToPlay: "white",
+        clock: { system: "absolute", black: 595, white: 600, activeColor: "white" },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const movePlayed = messages.find((m) => m.type === "move_played");
+    expect(movePlayed).toBeDefined();
+    expect(movePlayed?.type === "move_played" && movePlayed.data.pos).toEqual([3, 3]);
+    client.close();
+  });
+
+  it("receives game_over", async () => {
+    const messages: ServerMessage[] = [];
+    const client = new BikClient(GAME_URL, TOKEN, {
+      onMessage: (msg) => messages.push(msg),
+      WebSocketImpl: WS as unknown as typeof WebSocket,
+    });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 50));
+
+    server.send({
+      type: "game_over",
+      data: { result: "B+R", winner: "black", scoreBlack: null, scoreWhite: null },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const gameOver = messages.find((m) => m.type === "game_over");
+    expect(gameOver?.type === "game_over" && gameOver.data.result).toBe("B+R");
+    client.close();
+  });
+});

--- a/bik/bik-js/test/game.test.ts
+++ b/bik/bik-js/test/game.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { WebSocketServer, WebSocket as WS } from "ws";
+import { BikClient } from "../src/client.js";
+import type { ServerMessage, ClientMessage } from "../src/types/ws.js";
+import type { Color, Clock, Position } from "../src/types/common.js";
+
+const PORT = 9877;
+const WS_IMPL = WS as unknown as typeof WebSocket;
+
+/**
+ * A minimal BIK game server that tracks turns, broadcasts moves to both
+ * players, and handles resignation. Enough to prove two players can
+ * complete a game through the protocol.
+ */
+function startGameServer() {
+  const wss = new WebSocketServer({ port: PORT });
+  const clients = new Map<WS, { color: Color }>();
+  let nextToPlay: Color = "black";
+  let moveNumber = 0;
+
+  const clock = (): Clock => ({
+    system: "absolute",
+    black: 600,
+    white: 600,
+    activeColor: nextToPlay,
+  });
+
+  const broadcast = (msg: ServerMessage) => {
+    const payload = JSON.stringify(msg);
+    for (const ws of clients.keys()) ws.send(payload);
+  };
+
+  wss.on("connection", (ws) => {
+    // First connection is black, second is white
+    const color: Color = clients.size === 0 ? "black" : "white";
+    clients.set(ws, { color });
+
+    ws.send(JSON.stringify({
+      type: "game_state",
+      data: { moves: [], phase: "active", nextToPlay, clock: clock() },
+    } satisfies ServerMessage));
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString()) as ClientMessage;
+      const { color: playerColor } = clients.get(ws)!;
+
+      if (msg.type === "move") {
+        if (playerColor !== nextToPlay) {
+          ws.send(JSON.stringify({
+            type: "move_rejected",
+            data: { reason: "not_your_turn" },
+          } satisfies ServerMessage));
+          return;
+        }
+
+        moveNumber++;
+        nextToPlay = nextToPlay === "black" ? "white" : "black";
+
+        broadcast({
+          type: "move_played",
+          data: {
+            pos: msg.data.pos,
+            moveNumber,
+            color: playerColor,
+            captures: [],
+            nextToPlay,
+            clock: clock(),
+          },
+        });
+      }
+
+      if (msg.type === "resign") {
+        const winner: Color = playerColor === "black" ? "white" : "black";
+        broadcast({
+          type: "game_over",
+          data: { result: `${winner[0].toUpperCase()}+R`, winner, scoreBlack: null, scoreWhite: null },
+        });
+      }
+    });
+  });
+
+  return { wss };
+}
+
+function makeClient(messages: ServerMessage[]) {
+  return new BikClient(`ws://localhost:${PORT}`, "token", {
+    onMessage: (msg) => messages.push(msg),
+    WebSocketImpl: WS_IMPL,
+  });
+}
+
+const wait = (ms = 50) => new Promise((r) => setTimeout(r, ms));
+
+describe("two players play a game", () => {
+  it("plays several moves then black resigns", async () => {
+    const { wss } = startGameServer();
+
+    const blackMsgs: ServerMessage[] = [];
+    const whiteMsgs: ServerMessage[] = [];
+    const black = makeClient(blackMsgs);
+    const white = makeClient(whiteMsgs);
+
+    black.connect();
+    await wait();
+    white.connect();
+    await wait();
+
+    // Both should have received game_state
+    expect(blackMsgs[0].type).toBe("game_state");
+    expect(whiteMsgs[0].type).toBe("game_state");
+
+    // Black plays D4
+    black.send({ type: "move", data: { pos: [3, 3] } });
+    await wait();
+
+    // Both see move_played
+    const blackMove = blackMsgs.find((m) => m.type === "move_played");
+    const whiteMove = whiteMsgs.find((m) => m.type === "move_played");
+    expect(blackMove?.type === "move_played" && blackMove.data.pos).toEqual([3, 3]);
+    expect(whiteMove?.type === "move_played" && whiteMove.data.pos).toEqual([3, 3]);
+
+    // White plays Q16
+    white.send({ type: "move", data: { pos: [15, 2] } });
+    await wait();
+
+    // Black resigns
+    black.send({ type: "resign", data: {} });
+    await wait();
+
+    // Both should see game_over with white winning
+    const blackGameOver = blackMsgs.find((m) => m.type === "game_over");
+    const whiteGameOver = whiteMsgs.find((m) => m.type === "game_over");
+    expect(blackGameOver?.type === "game_over" && blackGameOver.data.result).toBe("W+R");
+    expect(whiteGameOver?.type === "game_over" && whiteGameOver.data.winner).toBe("white");
+
+    black.close();
+    white.close();
+    wss.close();
+  });
+
+  it("rejects a move played out of turn", async () => {
+    const { wss } = startGameServer();
+
+    const blackMsgs: ServerMessage[] = [];
+    const whiteMsgs: ServerMessage[] = [];
+    const black = makeClient(blackMsgs);
+    const white = makeClient(whiteMsgs);
+
+    black.connect();
+    await wait();
+    white.connect();
+    await wait();
+
+    // White tries to play first (it's black's turn)
+    white.send({ type: "move", data: { pos: [3, 3] } });
+    await wait();
+
+    const rejected = whiteMsgs.find((m) => m.type === "move_rejected");
+    expect(rejected?.type === "move_rejected" && rejected.data.reason).toBe("not_your_turn");
+
+    black.close();
+    white.close();
+    wss.close();
+  });
+});

--- a/bik/bik-js/tsconfig.json
+++ b/bik/bik-js/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/bik/e2e/Dockerfile.server
+++ b/bik/e2e/Dockerfile.server
@@ -1,0 +1,9 @@
+FROM golang:1.24-alpine
+WORKDIR /app
+RUN apk add --no-cache git
+COPY server/go.mod server/go.sum* ./
+RUN go mod download
+COPY server/ ./
+RUN go build -o frogs_cafe .
+EXPOSE 8080
+CMD ["./frogs_cafe"]

--- a/bik/e2e/docker-compose.yml
+++ b/bik/e2e/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - ./init-dbs.sql:/docker-entrypoint-initdb.d/init-dbs.sql
+
+  server-a:
+    build:
+      context: ../..
+      dockerfile: bik/e2e/Dockerfile.server
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/frogs_cafe_a?sslmode=disable
+      PORT: 8080
+      BASE_URL: http://server-a:8080
+      ENVIRONMENT: e2e
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+
+  server-b:
+    build:
+      context: ../..
+      dockerfile: bik/e2e/Dockerfile.server
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/frogs_cafe_b?sslmode=disable
+      PORT: 8080
+      BASE_URL: http://server-b:8080
+      ENVIRONMENT: e2e
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8081:8080"
+
+  test:
+    image: node:22-alpine
+    working_dir: /app
+    volumes:
+      - ../../bik:/app
+    command: sh -c "cd /app/bik-js && npm install --silent && npx tsx /app/e2e/test.ts"
+    depends_on:
+      - server-a
+      - server-b
+    environment:
+      SERVER_A: http://server-a:8080
+      SERVER_B: http://server-b:8080

--- a/bik/e2e/docker-compose.yml
+++ b/bik/e2e/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     working_dir: /app
     volumes:
       - ../../bik:/app
-    command: sh -c "cd /app/bik-js && npm install --silent && npx tsx /app/e2e/test.ts"
+    command: sh -c "cd /app/bik-js && npm install --silent && NODE_PATH=/app/bik-js/node_modules npx tsx /app/e2e/test.ts"
     depends_on:
       - server-a
       - server-b

--- a/bik/e2e/init-dbs.sql
+++ b/bik/e2e/init-dbs.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE frogs_cafe_a;
+CREATE DATABASE frogs_cafe_b;

--- a/bik/e2e/test.ts
+++ b/bik/e2e/test.ts
@@ -65,8 +65,10 @@ async function createChallenge(server: string, token: string) {
   return res.json() as Promise<{ object: { id: string } }>;
 }
 
-async function getBIKToken(server: string, token: string, gameID: string) {
-  const res = await fetch(`${server}/api/v1/bik/token/${gameID}`, {
+async function getBIKToken(server: string, token: string, gameID: string, gameURI?: string) {
+  const url = new URL(`${server}/api/v1/bik/token/${gameID}`);
+  if (gameURI) url.searchParams.set("gameURI", gameURI);
+  const res = await fetch(url, {
     method: "POST",
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -87,6 +89,7 @@ function connectAndCollect(url: string, token: string): { messages: ServerMessag
 
 // ---- main ----
 
+async function main() {
 console.log("Waiting for servers...");
 await waitForServer(A);
 await waitForServer(B);
@@ -117,9 +120,9 @@ console.log(`  Black: ${game.black}`);
 console.log(`  White: ${game.white}`);
 console.log(`  WebSocket: ${game.websocket}\n`);
 
-// 4. Bob gets a BIK token from server B
+// 4. Bob gets a BIK token from server B (game lives on server A, pass the URI)
 console.log("Bob gets a BIK token from server B...");
-const bikToken = await getBIKToken(B, bobToken, gameID);
+const bikToken = await getBIKToken(B, bobToken, gameID, game.url);
 console.log("✓ BIK token issued\n");
 
 // 5. Both connect to server A's WebSocket
@@ -163,3 +166,6 @@ alice.close();
 bob.close();
 
 console.log("🎉 E2E test passed — two servers, real WebSocket, real database");
+}
+
+main().catch((e) => { console.error("E2E FAILED:", e.message); process.exit(1); });

--- a/bik/e2e/test.ts
+++ b/bik/e2e/test.ts
@@ -1,0 +1,165 @@
+/**
+ * BIK E2E test: two frogs_cafe instances play a game across servers.
+ *
+ * Server A hosts the game. Alice is a local player on A.
+ * Server B is the guest. Bob is a local player on B.
+ *
+ * Flow:
+ *  1. Register alice on server A, bob on server B
+ *  2. Alice creates a BIK challenge on server A
+ *  3. Bob (on server B) accepts the challenge → server A creates a game
+ *  4. Bob gets a BIK token from server B for the game
+ *  5. Both connect to server A's WebSocket
+ *  6. They alternate moves; bob resigns
+ *  7. Both receive game_over
+ */
+
+import { WebSocket } from "ws";
+import { buildAcceptChallenge, postActivity, BikClient } from "../bik-js/src/index.js";
+import type { ServerMessage, CreateGameActivity } from "../bik-js/src/index.js";
+
+const A = process.env.SERVER_A ?? "http://localhost:8080";
+const B = process.env.SERVER_B ?? "http://localhost:8081";
+
+const WS_A = A.replace("http", "ws");
+const WS_IMPL = WebSocket as unknown as typeof globalThis.WebSocket;
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForServer(url: string, retries = 20) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(`${url}/health`);
+      if (res.ok) return;
+    } catch {}
+    await sleep(1000);
+  }
+  throw new Error(`Server not ready: ${url}`);
+}
+
+async function register(server: string, username: string, password: string) {
+  const res = await fetch(`${server}/api/v1/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, email: `${username}@example.com`, password }),
+  });
+  if (!res.ok) throw new Error(`register ${username} failed: ${res.status} ${await res.text()}`);
+  const data = await res.json() as { token: string };
+  return data.token;
+}
+
+async function createChallenge(server: string, token: string) {
+  const res = await fetch(`${server}/api/v1/bik/challenges`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      boardSize: 9,
+      timeControl: { system: "absolute", mainTime: 300 },
+      colorPreference: "any",
+      expiresIn: 3600,
+    }),
+  });
+  if (!res.ok) throw new Error(`createChallenge failed: ${res.status} ${await res.text()}`);
+  return res.json() as Promise<{ object: { id: string } }>;
+}
+
+async function getBIKToken(server: string, token: string, gameID: string) {
+  const res = await fetch(`${server}/api/v1/bik/token/${gameID}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getBIKToken failed: ${res.status} ${await res.text()}`);
+  const data = await res.json() as { token: string };
+  return data.token;
+}
+
+function connectAndCollect(url: string, token: string): { messages: ServerMessage[]; client: BikClient } {
+  const messages: ServerMessage[] = [];
+  const client = new BikClient(url, token, {
+    onMessage: (msg) => messages.push(msg),
+    WebSocketImpl: WS_IMPL,
+  });
+  client.connect();
+  return { messages, client };
+}
+
+// ---- main ----
+
+console.log("Waiting for servers...");
+await waitForServer(A);
+await waitForServer(B);
+console.log("✓ Both servers ready\n");
+
+// 1. Register users
+console.log("Registering alice on server A and bob on server B...");
+const aliceToken = await register(A, "alice", "password123");
+const bobToken   = await register(B, "bob",   "password123");
+console.log("✓ Users registered\n");
+
+// 2. Alice creates a challenge on server A
+console.log("Alice creates a challenge...");
+const challenge = await createChallenge(A, aliceToken);
+const challengeURI = challenge.object.id;
+console.log(`✓ Challenge created: ${challengeURI}\n`);
+
+// 3. Bob accepts the challenge — server A responds with a CreateGame activity
+console.log("Bob accepts the challenge...");
+const accept = buildAcceptChallenge(`${B}/users/bob`, challengeURI);
+const res = await postActivity(`${A}/bik/inbox`, accept);
+if (!res.ok) throw new Error(`Accept failed: ${res.status} ${await res.text()}`);
+const gameActivity = await res.json() as CreateGameActivity;
+const game = gameActivity.object.attachment;
+const gameID = game.id;
+console.log(`✓ Game created: ${game.url}`);
+console.log(`  Black: ${game.black}`);
+console.log(`  White: ${game.white}`);
+console.log(`  WebSocket: ${game.websocket}\n`);
+
+// 4. Bob gets a BIK token from server B
+console.log("Bob gets a BIK token from server B...");
+const bikToken = await getBIKToken(B, bobToken, gameID);
+console.log("✓ BIK token issued\n");
+
+// 5. Both connect to server A's WebSocket
+console.log("Connecting to server A's WebSocket...");
+const wsURL = `${WS_A}/ws/games/${gameID}`;
+const { messages: aliceMsgs, client: alice } = connectAndCollect(wsURL, aliceToken);
+await sleep(200);
+const { messages: bobMsgs, client: bob } = connectAndCollect(wsURL, bikToken);
+await sleep(200);
+
+if (!aliceMsgs.find(m => m.type === "game_state")) throw new Error("Alice did not receive game_state");
+if (!bobMsgs.find(m => m.type === "game_state")) throw new Error("Bob did not receive game_state");
+console.log("✓ Both players connected and received game_state\n");
+
+// 6. Play some moves (alice is black, bob is white)
+console.log("Playing moves...");
+alice.send({ type: "move", data: { pos: [2, 2] } }); // alice plays
+await sleep(200);
+bob.send({ type: "move", data: { pos: [6, 6] } });   // bob plays
+await sleep(200);
+alice.send({ type: "move", data: { pos: [2, 6] } }); // alice plays
+await sleep(200);
+
+const movesPlayed = aliceMsgs.filter(m => m.type === "move_played");
+console.log(`✓ ${movesPlayed.length} moves played\n`);
+
+// 7. Bob resigns
+console.log("Bob resigns...");
+bob.send({ type: "resign", data: {} });
+await sleep(200);
+
+const aliceGameOver = aliceMsgs.find(m => m.type === "game_over");
+const bobGameOver   = bobMsgs.find(m => m.type === "game_over");
+
+if (!aliceGameOver || !bobGameOver) throw new Error("game_over not received by both players");
+
+console.log("✓ game_over received by both players");
+console.log(`  Result: ${aliceGameOver.type === "game_over" ? aliceGameOver.data.result : "?"}\n`);
+
+alice.close();
+bob.close();
+
+console.log("🎉 E2E test passed — two servers, real WebSocket, real database");

--- a/bik/e2e/test.ts
+++ b/bik/e2e/test.ts
@@ -57,7 +57,7 @@ async function createChallenge(server: string, token: string) {
     body: JSON.stringify({
       boardSize: 9,
       timeControl: { system: "absolute", mainTime: 300 },
-      colorPreference: "any",
+      colorAssignment: "random",
       expiresIn: 3600,
     }),
   });

--- a/bik/schema/ap.json
+++ b/bik/schema/ap.json
@@ -3,6 +3,7 @@
   "$id": "https://bik.example/schema/ap.json",
   "title": "BIK ActivityPub Activities",
   "description": "ActivityPub activities used for BIK matchmaking and results",
+  "$comment": "Three variants share type='Create' and are distinguished by object.attachment.type (BikChallenge, BikGame, BikGameResult). Validators should inspect object.attachment.type first to select the correct branch rather than trying all three oneOf branches blindly.",
   "$defs": {
     "TimeControl": {
       "oneOf": [
@@ -41,22 +42,23 @@
         "type":            { "const": "BikChallenge" },
         "boardSize":       { "type": "integer", "minimum": 2 },
         "timeControl":     { "$ref": "#/$defs/TimeControl" },
-        "colorPreference": { "type": "string", "enum": ["black", "white", "any"] },
+        "colorAssignment": { "type": "string", "enum": ["black", "white", "random"] },
+        "komi":            { "type": "number", "description": "Point compensation for white. Default 0." },
         "expiresAt":       { "type": "string", "format": "date-time" }
       },
-      "required": ["type", "boardSize", "timeControl", "colorPreference", "expiresAt"]
+      "required": ["type", "boardSize", "timeControl", "colorAssignment", "expiresAt"]
     },
     "BikGame": {
       "type": "object",
       "properties": {
         "type":      { "const": "BikGame" },
-        "id":        { "type": "string" },
+        "id":        { "type": "string", "format": "uri", "description": "Full game URI — canonical identifier and human-readable page" },
         "black":     { "type": "string", "format": "uri" },
         "white":     { "type": "string", "format": "uri" },
-        "url":       { "type": "string", "format": "uri", "description": "Human-readable game page" },
+        "komi":      { "type": "number", "description": "Point compensation for white. Default 0." },
         "websocket": { "type": "string", "description": "wss:// URL for live play" }
       },
-      "required": ["type", "id", "black", "white", "url", "websocket"]
+      "required": ["type", "id", "black", "white", "websocket"]
     },
     "BikGameResult": {
       "type": "object",

--- a/bik/schema/ap.json
+++ b/bik/schema/ap.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bik.example/schema/ap.json",
+  "title": "BIK ActivityPub Activities",
+  "description": "ActivityPub activities used for BIK matchmaking and results",
+  "$defs": {
+    "TimeControl": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "system":     { "const": "byoyomi" },
+            "mainTime":   { "type": "number", "description": "Seconds" },
+            "periods":    { "type": "integer", "minimum": 1 },
+            "periodTime": { "type": "number" }
+          },
+          "required": ["system", "mainTime", "periods", "periodTime"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "system":    { "const": "fischer" },
+            "mainTime":  { "type": "number" },
+            "increment": { "type": "number" }
+          },
+          "required": ["system", "mainTime", "increment"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "system":   { "const": "absolute" },
+            "mainTime": { "type": "number" }
+          },
+          "required": ["system", "mainTime"]
+        }
+      ]
+    },
+    "BikChallenge": {
+      "type": "object",
+      "properties": {
+        "type":            { "const": "BikChallenge" },
+        "boardSize":       { "type": "integer", "minimum": 2 },
+        "timeControl":     { "$ref": "#/$defs/TimeControl" },
+        "colorPreference": { "type": "string", "enum": ["black", "white", "any"] },
+        "expiresAt":       { "type": "string", "format": "date-time" }
+      },
+      "required": ["type", "boardSize", "timeControl", "colorPreference", "expiresAt"]
+    },
+    "BikGame": {
+      "type": "object",
+      "properties": {
+        "type":      { "const": "BikGame" },
+        "id":        { "type": "string" },
+        "black":     { "type": "string", "format": "uri" },
+        "white":     { "type": "string", "format": "uri" },
+        "url":       { "type": "string", "format": "uri", "description": "Human-readable game page" },
+        "websocket": { "type": "string", "description": "wss:// URL for live play" }
+      },
+      "required": ["type", "id", "black", "white", "url", "websocket"]
+    },
+    "BikGameResult": {
+      "type": "object",
+      "properties": {
+        "type":   { "const": "BikGameResult" },
+        "winner": { "type": "string", "format": "uri" },
+        "result": { "$ref": "common.json#/$defs/GameResult" },
+        "sgf":    { "type": "string", "format": "uri" }
+      },
+      "required": ["type", "winner", "result"]
+    }
+  },
+  "oneOf": [
+    {
+      "title": "CreateChallenge",
+      "description": "A player advertises an open challenge",
+      "type": "object",
+      "properties": {
+        "type":   { "const": "Create" },
+        "actor":  { "type": "string", "format": "uri" },
+        "object": {
+          "type": "object",
+          "properties": {
+            "type":         { "const": "Note" },
+            "id":           { "type": "string", "format": "uri" },
+            "attributedTo": { "type": "string", "format": "uri" },
+            "content":      { "type": "string" },
+            "attachment":   { "$ref": "#/$defs/BikChallenge" }
+          },
+          "required": ["type", "id", "attributedTo", "content", "attachment"]
+        }
+      },
+      "required": ["type", "actor", "object"]
+    },
+    {
+      "title": "AcceptChallenge",
+      "description": "A remote player accepts an open challenge",
+      "type": "object",
+      "properties": {
+        "type":   { "const": "Accept" },
+        "actor":  { "type": "string", "format": "uri" },
+        "object": { "type": "string", "format": "uri", "description": "URI of the challenge Note" }
+      },
+      "required": ["type", "actor", "object"]
+    },
+    {
+      "title": "UndoChallenge",
+      "description": "Challenge withdrawn (accepted by someone else, expired, or cancelled)",
+      "type": "object",
+      "properties": {
+        "type":   { "const": "Undo" },
+        "actor":  { "type": "string", "format": "uri" },
+        "object": { "type": "string", "format": "uri", "description": "URI of the challenge Note" }
+      },
+      "required": ["type", "actor", "object"]
+    },
+    {
+      "title": "CreateGame",
+      "description": "Host announces a game has started",
+      "type": "object",
+      "properties": {
+        "type":   { "const": "Create" },
+        "actor":  { "type": "string", "format": "uri" },
+        "object": {
+          "type": "object",
+          "properties": {
+            "type":       { "const": "Note" },
+            "id":         { "type": "string", "format": "uri" },
+            "content":    { "type": "string" },
+            "inReplyTo":  { "type": "string", "format": "uri" },
+            "attachment": { "$ref": "#/$defs/BikGame" }
+          },
+          "required": ["type", "id", "content", "inReplyTo", "attachment"]
+        }
+      },
+      "required": ["type", "actor", "object"]
+    },
+    {
+      "title": "CreateGameResult",
+      "description": "Host announces the game result",
+      "type": "object",
+      "properties": {
+        "type":   { "const": "Create" },
+        "actor":  { "type": "string", "format": "uri" },
+        "object": {
+          "type": "object",
+          "properties": {
+            "type":       { "const": "Note" },
+            "id":         { "type": "string", "format": "uri" },
+            "content":    { "type": "string" },
+            "inReplyTo":  { "type": "string", "format": "uri" },
+            "attachment": { "$ref": "#/$defs/BikGameResult" }
+          },
+          "required": ["type", "id", "content", "inReplyTo", "attachment"]
+        }
+      },
+      "required": ["type", "actor", "object"]
+    }
+  ]
+}

--- a/bik/schema/common.json
+++ b/bik/schema/common.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bik.example/schema/common.json",
+  "title": "BIK Common Types",
+  "$defs": {
+    "Position": {
+      "description": "A board position as [col, row] (zero-indexed), or null for pass",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        { "type": "null" }
+      ]
+    },
+    "Color": {
+      "type": "string",
+      "enum": ["black", "white"]
+    },
+    "GamePhase": {
+      "type": "string",
+      "enum": ["active", "scoring", "finished"]
+    },
+    "GameResult": {
+      "description": "SGF-style result string: B+R, W+3.5, B+T, etc.",
+      "type": "string",
+      "pattern": "^(B|W)\\+(R|T|[0-9]+(\\.[0-9]+)?)$"
+    },
+    "ByoyomiPlayerClock": {
+      "type": "object",
+      "properties": {
+        "main":       { "type": "number", "description": "Main time remaining in seconds" },
+        "periods":    { "type": "integer", "minimum": 0 },
+        "periodTime": { "type": "number", "description": "Seconds per period" }
+      },
+      "required": ["main", "periods", "periodTime"]
+    },
+    "Clock": {
+      "oneOf": [
+        {
+          "description": "Byo-yomi clock",
+          "type": "object",
+          "properties": {
+            "system":      { "const": "byoyomi" },
+            "black":       { "$ref": "#/$defs/ByoyomiPlayerClock" },
+            "white":       { "$ref": "#/$defs/ByoyomiPlayerClock" },
+            "activeColor": { "$ref": "#/$defs/Color" }
+          },
+          "required": ["system", "black", "white", "activeColor"]
+        },
+        {
+          "description": "Fischer clock",
+          "type": "object",
+          "properties": {
+            "system":      { "const": "fischer" },
+            "black":       { "type": "number", "description": "Seconds remaining" },
+            "white":       { "type": "number" },
+            "increment":   { "type": "number", "description": "Seconds added per move" },
+            "activeColor": { "$ref": "#/$defs/Color" }
+          },
+          "required": ["system", "black", "white", "increment", "activeColor"]
+        },
+        {
+          "description": "Absolute (no time added)",
+          "type": "object",
+          "properties": {
+            "system":      { "const": "absolute" },
+            "black":       { "type": "number" },
+            "white":       { "type": "number" },
+            "activeColor": { "$ref": "#/$defs/Color" }
+          },
+          "required": ["system", "black", "white", "activeColor"]
+        }
+      ]
+    }
+  }
+}

--- a/bik/schema/ws-client.json
+++ b/bik/schema/ws-client.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bik.example/schema/ws-client.json",
+  "title": "BIK WebSocket Client Messages",
+  "description": "Messages sent from a player client to the host server",
+  "oneOf": [
+    {
+      "title": "move",
+      "description": "Place a stone or pass",
+      "type": "object",
+      "properties": {
+        "type": { "const": "move" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "pos": { "$ref": "common.json#/$defs/Position" }
+          },
+          "required": ["pos"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "resign",
+      "type": "object",
+      "properties": {
+        "type": { "const": "resign" },
+        "data": { "type": "object" }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "mark_dead",
+      "description": "Mark stones as dead during scoring phase",
+      "type": "object",
+      "properties": {
+        "type": { "const": "mark_dead" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "positions": {
+              "type": "array",
+              "items": { "$ref": "common.json#/$defs/Position" }
+            }
+          },
+          "required": ["positions"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "score_accept",
+      "description": "Accept the current score",
+      "type": "object",
+      "properties": {
+        "type": { "const": "score_accept" },
+        "data": { "type": "object" }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "score_reject",
+      "description": "Reject the score and resume play",
+      "type": "object",
+      "properties": {
+        "type": { "const": "score_reject" },
+        "data": { "type": "object" }
+      },
+      "required": ["type", "data"]
+    }
+  ]
+}

--- a/bik/schema/ws-server.json
+++ b/bik/schema/ws-server.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bik.example/schema/ws-server.json",
+  "title": "BIK WebSocket Server Messages",
+  "description": "Messages broadcast from the host server to all connected clients",
+  "oneOf": [
+    {
+      "title": "game_state",
+      "description": "Full game state — sent immediately on connect and on request",
+      "type": "object",
+      "properties": {
+        "type": { "const": "game_state" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "moves":       {
+              "type": "array",
+              "items": { "$ref": "common.json#/$defs/Position" },
+              "description": "Ordered list of all moves played so far"
+            },
+            "phase":       { "$ref": "common.json#/$defs/GamePhase" },
+            "nextToPlay":  { "$ref": "common.json#/$defs/Color" },
+            "clock":       { "$ref": "common.json#/$defs/Clock" }
+          },
+          "required": ["moves", "phase", "nextToPlay", "clock"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "move_played",
+      "description": "A move was accepted and applied",
+      "type": "object",
+      "properties": {
+        "type": { "const": "move_played" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "pos":        { "$ref": "common.json#/$defs/Position" },
+            "moveNumber": { "type": "integer", "minimum": 1 },
+            "color":      { "$ref": "common.json#/$defs/Color" },
+            "captures":   {
+              "type": "array",
+              "items": { "$ref": "common.json#/$defs/Position" }
+            },
+            "nextToPlay": { "$ref": "common.json#/$defs/Color" },
+            "clock":      { "$ref": "common.json#/$defs/Clock" }
+          },
+          "required": ["pos", "moveNumber", "color", "captures", "nextToPlay", "clock"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "move_rejected",
+      "description": "A move was rejected by the host",
+      "type": "object",
+      "properties": {
+        "type": { "const": "move_rejected" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "reason": {
+              "type": "string",
+              "enum": ["ko", "occupied", "suicide", "not_your_turn", "game_not_active"]
+            }
+          },
+          "required": ["reason"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "clock",
+      "description": "Periodic clock update",
+      "type": "object",
+      "properties": {
+        "type": { "const": "clock" },
+        "data": { "$ref": "common.json#/$defs/Clock" }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "phase_change",
+      "description": "The game phase has changed",
+      "type": "object",
+      "properties": {
+        "type": { "const": "phase_change" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "phase": { "$ref": "common.json#/$defs/GamePhase" }
+          },
+          "required": ["phase"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "dead_stones",
+      "description": "Updated dead stone markings during scoring",
+      "type": "object",
+      "properties": {
+        "type": { "const": "dead_stones" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "positions": {
+              "type": "array",
+              "items": { "$ref": "common.json#/$defs/Position" }
+            }
+          },
+          "required": ["positions"]
+        }
+      },
+      "required": ["type", "data"]
+    },
+    {
+      "title": "game_over",
+      "description": "The game has ended",
+      "type": "object",
+      "properties": {
+        "type": { "const": "game_over" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "result": { "$ref": "common.json#/$defs/GameResult" },
+            "winner": { "$ref": "common.json#/$defs/Color" },
+            "scoreBlack": { "type": ["number", "null"] },
+            "scoreWhite": { "type": ["number", "null"] }
+          },
+          "required": ["result", "winner", "scoreBlack", "scoreWhite"]
+        }
+      },
+      "required": ["type", "data"]
+    }
+  ]
+}

--- a/bik/spec/protocol.md
+++ b/bik/spec/protocol.md
@@ -25,6 +25,11 @@ Once a game begins, all gameplay flows through the host. The guest server may ob
 
 Challenges use ActivityPub activities for federation.
 
+All BIK activities MUST include `to` and `cc` for correct AP delivery routing:
+- Public broadcasts (challenges, game announcements, results): `to: [Public]`, `cc` includes the actor's followers collection and any directly addressed participants
+- Directed activities (Accept, direct challenges): `to` contains only the addressed actor(s), no `cc` required
+- The followers collection URL is discovered from the actor document (`followers` field)
+
 ### 1. Create Challenge
 
 A player creates an open challenge on their server.
@@ -34,6 +39,8 @@ A player creates an open challenge on their server.
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Create",
   "actor": "https://server-a.example/users/alice",
+  "to": ["https://www.w3.org/ns/activitystreams#Public"],
+  "cc": ["https://server-a.example/users/alice/followers"],
   "object": {
     "type": "Note",
     "id": "https://server-a.example/challenges/abc123",
@@ -48,7 +55,8 @@ A player creates an open challenge on their server.
         "periods": 5,
         "periodTime": 30
       },
-      "colorPreference": "any",
+      "colorAssignment": "random",
+      "komi": 6.5,
       "expiresAt": "2024-03-10T15:30:00Z"
     }
   }
@@ -57,7 +65,42 @@ A player creates an open challenge on their server.
 
 The `Note` is renderable by standard ActivityPub clients (Mastodon, etc). The `attachment` contains machine-readable game parameters.
 
+Challenges MAY be directed at a specific player instead of broadcast publicly. A direct challenge addresses the target actor in `to` and omits `Public`:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "actor": "https://server-a.example/users/alice",
+  "to": ["https://server-b.example/users/bob"],
+  "object": {
+    "type": "Note",
+    "id": "https://server-a.example/challenges/abc123",
+    "attributedTo": "https://server-a.example/users/alice",
+    "content": "Hey @bob@server-b.example, want a game? 19x19, 10min + 5x30s byo-yomi",
+    "attachment": {
+      "type": "BikChallenge",
+      "boardSize": 19,
+      "timeControl": { "system": "byoyomi", "mainTime": 600, "periods": 5, "periodTime": 30 },
+      "colorAssignment": "random",
+      "expiresAt": "2024-03-10T15:30:00Z"
+    }
+  }
+}
+```
+
+Servers receiving a direct challenge SHOULD only allow the addressed player to accept it. Clients can determine challenge visibility by inspecting `to`: if it contains `https://www.w3.org/ns/activitystreams#Public` the challenge is open; otherwise it is direct.
+
 Challenges expire at `expiresAt`. Servers SHOULD reject `Accept` activities for expired challenges.
+
+`komi` is the point compensation given to white. If omitted, it defaults to `0`. Negative values are valid.
+
+`colorAssignment` determines how colors are assigned when the challenge is accepted:
+- `"black"` — the challenger (the player who created the challenge) plays black
+- `"white"` — the challenger plays white
+- `"random"` — the host assigns colors randomly on accept
+
+<!-- TODO: rating-based color assignment (stronger player takes white) — requires rating exchange between servers -->
 
 ### 2. Accept Challenge
 
@@ -68,6 +111,7 @@ A remote player accepts:
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Accept",
   "actor": "https://server-b.example/users/bob",
+  "to": ["https://server-a.example/users/alice"],
   "object": "https://server-a.example/challenges/abc123"
 }
 ```
@@ -83,6 +127,8 @@ When a challenge is accepted or the creator cancels it, the host broadcasts an `
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Undo",
   "actor": "https://server-a.example/users/alice",
+  "to": ["https://www.w3.org/ns/activitystreams#Public"],
+  "cc": ["https://server-a.example/users/alice/followers"],
   "object": "https://server-a.example/challenges/abc123"
 }
 ```
@@ -98,6 +144,8 @@ Host notifies both parties and their followers:
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Create",
   "actor": "https://server-a.example/users/alice",
+  "to": ["https://www.w3.org/ns/activitystreams#Public"],
+  "cc": ["https://server-a.example/users/alice/followers", "https://server-b.example/users/bob"],
   "object": {
     "type": "Note",
     "id": "https://server-a.example/games/xyz789",
@@ -105,17 +153,17 @@ Host notifies both parties and their followers:
     "inReplyTo": "https://server-a.example/challenges/abc123",
     "attachment": {
       "type": "BikGame",
-      "id": "xyz789",
+      "id": "https://server-a.example/games/xyz789",
       "black": "https://server-a.example/users/alice",
       "white": "https://server-b.example/users/bob",
-      "url": "https://server-a.example/games/xyz789",
+      "komi": 6.5,
       "websocket": "wss://server-a.example/ws/games/xyz789"
     }
   }
 }
 ```
 
-The `url` is a human-readable page to watch the game. The `websocket` is for live clients.
+`BikGame.id` is the canonical game URI — both its AP identifier and the human-readable page. The `websocket` is for live clients.
 
 ## Gameplay
 
@@ -123,25 +171,38 @@ The `url` is a human-readable page to watch the game. The `websocket` is for liv
 
 The guest player needs to authenticate to the host's WebSocket. Flow:
 
-1. Guest server issues a **signed token** for its player:
+1. Guest player requests a signed token from **their own server**:
+   ```
+   POST /api/v1/bik/token?gameURI=https://server-a.example/games/xyz789
+   Authorization: <normal session credential>
+   ```
+   Response:
+   ```json
+   { "token": "<signed-jwt>" }
+   ```
+   The token payload is:
    ```json
    {
-     "player": "@bob@server-b.example",
+     "kid": "a3f2c1b4e5d6f7a8",
+     "player": "https://server-b.example/users/bob",
      "game": "https://server-a.example/games/xyz789",
      "exp": 1710000000
    }
    ```
-   Signed with the guest server's private key.
+   Signed with the guest server's private key. Tokens MUST have a short expiry (recommended: 5 minutes).
 
 2. Guest player connects to host WebSocket with token:
    ```
-   wss://server-a.example/ws/games/xyz789?token=<base64-encoded-token>
+   wss://server-a.example/ws/games/xyz789?token=<signed-jwt>
    ```
 
 3. Host verifies token by:
-   - Fetching guest server's public key (via `/.well-known/bik/keys`, cached)
-   - Validating signature and expiry
-   - Confirming player matches game participant
+   - Decoding the payload (base64, no key required) to read `player` and `kid`
+   - Extracting the guest server's domain from the `player` actor URI
+   - Fetching the guest server's JWK set (via `/.well-known/bik/keys`, cached) and selecting the key matching `kid` — re-fetching if `kid` is unknown
+   - Verifying the signature against that public key
+   - Confirming expiry has not passed
+   - Confirming `player` matches a participant in the named game
 
 Local players authenticate with their usual session token.
 
@@ -210,7 +271,7 @@ All messages share a common envelope:
 {
   "type": "game_state",
   "data": {
-    "moves": ["D4", "Q16", "pass"],
+    "moves": [[3, 3], [15, 2], null],
     "phase": "active",
     "clock": { ... },
     "nextToPlay": "black"
@@ -227,7 +288,8 @@ All messages share a common envelope:
     "moveNumber": 47,
     "color": "black",
     "captures": [[3, 4]],
-    "nextToPlay": "white"
+    "nextToPlay": "white",
+    "clock": {"system": "byoyomi", "black": {"main": 542, "periods": 4, "periodTime": 30}, "white": {"main": 600, "periods": 5, "periodTime": 30}, "activeColor": "white"}
   }
 }
 ```
@@ -292,6 +354,8 @@ When the game ends, host publishes result via ActivityPub:
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Create",
   "actor": "https://server-a.example/users/alice",
+  "to": ["https://www.w3.org/ns/activitystreams#Public"],
+  "cc": ["https://server-a.example/users/alice/followers", "https://server-b.example/users/bob"],
   "object": {
     "type": "Note",
     "id": "https://server-a.example/games/xyz789/result",
@@ -333,6 +397,29 @@ Returns:
 }
 ```
 
+### Actor Document
+
+The actor URI returned by WebFinger MUST dereference to an AP actor document:
+
+```
+GET https://server-a.example/users/alice
+Accept: application/activity+json
+```
+
+Returns:
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Person",
+  "id": "https://server-a.example/users/alice",
+  "preferredUsername": "alice",
+  "inbox": "https://server-a.example/bik/inbox",
+  "followers": "https://server-a.example/users/alice/followers"
+}
+```
+
+The `inbox` field is where AP activities (e.g. `Accept`) must be delivered. The `followers` collection URL is used by AP servers to fan out public activities to followers.
+
 ### Server Keys
 
 For token verification, servers expose public keys at a well-known endpoint:
@@ -341,7 +428,17 @@ For token verification, servers expose public keys at a well-known endpoint:
 GET /.well-known/bik/keys
 ```
 
-Returns JWK set for signature verification.
+Returns a JWK set for signature verification. Each key MUST include a `kid` (key ID) field:
+
+```json
+{
+  "keys": [
+    { "kty": "OKP", "crv": "Ed25519", "kid": "key-1", "x": "<base64url>" }
+  ]
+}
+```
+
+Signed tokens MUST include the `kid` of the signing key. When a verifying server encounters an unknown `kid`, it MUST re-fetch `/.well-known/bik/keys` rather than rejecting the token immediately — the signing server may have rotated keys. Servers rotating keys SHOULD retain the old key in the JWK set for at least 10 minutes to allow in-flight tokens to drain.
 
 ## Security Considerations
 
@@ -349,7 +446,7 @@ Returns JWK set for signature verification.
 - Tokens MUST have short expiry (recommend: 5 minutes)
 - Servers SHOULD rate-limit incoming federation requests
 - Hosts MUST validate that move submitters are game participants
-- Servers SHOULD implement HTTP Signatures for server-to-server requests (per ActivityPub spec)
+- Servers MUST implement HTTP Signatures for server-to-server requests (per ActivityPub spec) — without this, a malicious actor could spoof AP activities (e.g. fake Accept) to any BIK inbox
 
 ## Future Extensions
 

--- a/bik/spec/protocol.md
+++ b/bik/spec/protocol.md
@@ -145,24 +145,143 @@ The guest player needs to authenticate to the host's WebSocket. Flow:
 
 Local players authenticate with their usual session token.
 
+### Coordinates
+
+Board positions are `[col, row]` zero-indexed integer arrays. `[0, 0]` is the top-left corner. This works for any board size.
+
+Examples: `[0, 0]` (top-left), `[18, 18]` (bottom-right on 19x19), `[52, 52]` (bottom-right on 53x53).
+
+Pass is represented as `null`.
+
 ### WebSocket Messages
 
-Once connected, standard game messages flow:
+All messages share a common envelope:
 
 ```json
-{"type": "move", "data": {"x": 3, "y": 4, "moveNumber": 1}}
-{"type": "pass", "data": {"moveNumber": 42}}
-{"type": "resign", "data": {}}
-{"type": "clock", "data": {"black": 542, "white": 600}}
+{"type": "<message-type>", "data": { ... }}
 ```
 
-All clients (local and remote) receive the same broadcasts from the host.
+#### Client → Host
+
+| Type | Description |
+|------|-------------|
+| `move` | Place a stone or pass |
+| `resign` | Forfeit the game |
+| `mark_dead` | Mark stones as dead during scoring |
+| `score_accept` | Accept the current score |
+| `score_reject` | Reject score (resume play) |
+
+**`move`**
+```json
+{"type": "move", "data": {"pos": [3, 3]}}
+{"type": "move", "data": {"pos": null}}
+```
+
+**`resign`**
+```json
+{"type": "resign", "data": {}}
+```
+
+**`mark_dead`** *(scoring phase only)*
+```json
+{"type": "mark_dead", "data": {"positions": [[3, 3], [4, 3], [4, 4]]}}
+```
+
+**`score_accept`** / **`score_reject`**
+```json
+{"type": "score_accept", "data": {}}
+{"type": "score_reject", "data": {}}
+```
+
+#### Host → All Clients
+
+| Type | Description |
+|------|-------------|
+| `game_state` | Full game state (sent on connect/reconnect) |
+| `move_played` | A move was accepted and played |
+| `move_rejected` | A move was rejected |
+| `clock` | Current clock state |
+| `phase_change` | Game phase changed (e.g. active → scoring) |
+| `dead_stones` | Updated dead stone markings |
+| `game_over` | Game has ended |
+
+**`game_state`** — sent immediately on connection so clients can sync
+```json
+{
+  "type": "game_state",
+  "data": {
+    "moves": ["D4", "Q16", "pass"],
+    "phase": "active",
+    "clock": { ... },
+    "nextToPlay": "black"
+  }
+}
+```
+
+**`move_played`**
+```json
+{
+  "type": "move_played",
+  "data": {
+    "pos": [3, 3],
+    "moveNumber": 47,
+    "color": "black",
+    "captures": [[3, 4]],
+    "nextToPlay": "white"
+  }
+}
+```
+
+**`move_rejected`**
+```json
+{
+  "type": "move_rejected",
+  "data": {"reason": "ko"}
+}
+```
+Possible reasons: `ko`, `occupied`, `suicide`, `not_your_turn`, `game_not_active`.
+
+**`phase_change`**
+```json
+{"type": "phase_change", "data": {"phase": "scoring"}}
+```
+Phases: `active`, `scoring`, `finished`.
+
+**`game_over`**
+```json
+{
+  "type": "game_over",
+  "data": {
+    "result": "B+R",
+    "winner": "black",
+    "scoreBlack": null,
+    "scoreWhite": null
+  }
+}
+```
+`result` follows SGF convention: `B+R` (black wins by resignation), `W+3.5` (white wins by 3.5 points), `B+T` (black wins on time).
 
 ### Clock Sync
 
-The host is authoritative for time. Clients receive periodic `clock` messages. On move receipt, host broadcasts updated clock state.
+The host is authoritative for time. A `clock` message is broadcast after every move and periodically during play.
 
-For blitz games, clients should display server time, not local calculations.
+**`clock`** format varies by time system:
+
+```json
+{"type": "clock", "data": {"system": "byoyomi", "black": {"main": 542, "periods": 4, "periodTime": 30}, "white": {"main": 600, "periods": 5, "periodTime": 30}, "activeColor": "black"}}
+```
+```json
+{"type": "clock", "data": {"system": "fischer", "black": 312, "white": 480, "increment": 10, "activeColor": "white"}}
+```
+```json
+{"type": "clock", "data": {"system": "absolute", "black": 215, "white": 430, "activeColor": "black"}}
+```
+
+The host is the source of truth for time. If no `clock` message arrives within 5 seconds during active play, clients should request `game_state` to resync.
+
+### Reconnection
+
+Clients may disconnect and reconnect at any time. On reconnect, the host sends a `game_state` message immediately, giving the full move list and current clock. Clients should treat `game_state` as authoritative and discard any locally cached state.
 
 ## Game Completion
 

--- a/bik/spec/protocol.md
+++ b/bik/spec/protocol.md
@@ -1,0 +1,239 @@
+# BIK: Baduk InterKonnect Protocol
+
+**Version:** 0.1 (Draft)
+
+BIK enables Go (Baduk/Weiqi) games between players on different servers. It builds on ActivityPub for federation and identity, with WebSocket connections for low-latency gameplay.
+
+## Core Concepts
+
+### Identity
+
+Players are identified as `@username@domain`, which is the standard fediverse format:
+- `@alice@server-a.example`
+- `@bob@server-b.example`
+
+Servers are identified by domain and expose a WebFinger endpoint for actor discovery.
+
+### Server Roles
+
+- **Host**: The server where the game is played. Stores game state, validates moves, manages clocks.
+- **Guest**: The visiting player's home server. Vouches for player identity.
+
+Once a game begins, all gameplay flows through the host. The guest server may observe but does not relay moves.
+
+## Challenge Flow
+
+Challenges use ActivityPub activities for federation.
+
+### 1. Create Challenge
+
+A player creates an open challenge on their server.
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "actor": "https://server-a.example/users/alice",
+  "object": {
+    "type": "Note",
+    "id": "https://server-a.example/challenges/abc123",
+    "attributedTo": "https://server-a.example/users/alice",
+    "content": "Looking for a game! 19x19, 10min + 5x30s byo-yomi",
+    "attachment": {
+      "type": "BikChallenge",
+      "boardSize": 19,
+      "timeControl": {
+        "system": "byoyomi",
+        "mainTime": 600,
+        "periods": 5,
+        "periodTime": 30
+      },
+      "colorPreference": "any",
+      "expiresAt": "2024-03-10T15:30:00Z"
+    }
+  }
+}
+```
+
+The `Note` is renderable by standard ActivityPub clients (Mastodon, etc). The `attachment` contains machine-readable game parameters.
+
+Challenges expire at `expiresAt`. Servers SHOULD reject `Accept` activities for expired challenges.
+
+### 2. Accept Challenge
+
+A remote player accepts:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Accept",
+  "actor": "https://server-b.example/users/bob",
+  "object": "https://server-a.example/challenges/abc123"
+}
+```
+
+The challenge creator's server (server-a.example) becomes the **host**.
+
+### 3. Challenge Withdrawn
+
+When a challenge is accepted or the creator cancels it, the host broadcasts an `Undo` so followers know it's no longer available:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Undo",
+  "actor": "https://server-a.example/users/alice",
+  "object": "https://server-a.example/challenges/abc123"
+}
+```
+
+Clients receiving this should remove the challenge from any open challenge lists.
+
+### 4. Game Created
+
+Host notifies both parties and their followers:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "actor": "https://server-a.example/users/alice",
+  "object": {
+    "type": "Note",
+    "id": "https://server-a.example/games/xyz789",
+    "content": "@alice vs @bob@server-b.example — Game started! Watch at https://server-a.example/games/xyz789",
+    "inReplyTo": "https://server-a.example/challenges/abc123",
+    "attachment": {
+      "type": "BikGame",
+      "id": "xyz789",
+      "black": "https://server-a.example/users/alice",
+      "white": "https://server-b.example/users/bob",
+      "url": "https://server-a.example/games/xyz789",
+      "websocket": "wss://server-a.example/ws/games/xyz789"
+    }
+  }
+}
+```
+
+The `url` is a human-readable page to watch the game. The `websocket` is for live clients.
+
+## Gameplay
+
+### Authentication
+
+The guest player needs to authenticate to the host's WebSocket. Flow:
+
+1. Guest server issues a **signed token** for its player:
+   ```json
+   {
+     "player": "@bob@server-b.example",
+     "game": "https://server-a.example/games/xyz789",
+     "exp": 1710000000
+   }
+   ```
+   Signed with the guest server's private key.
+
+2. Guest player connects to host WebSocket with token:
+   ```
+   wss://server-a.example/ws/games/xyz789?token=<base64-encoded-token>
+   ```
+
+3. Host verifies token by:
+   - Fetching guest server's public key (via `/.well-known/bik/keys`, cached)
+   - Validating signature and expiry
+   - Confirming player matches game participant
+
+Local players authenticate with their usual session token.
+
+### WebSocket Messages
+
+Once connected, standard game messages flow:
+
+```json
+{"type": "move", "data": {"x": 3, "y": 4, "moveNumber": 1}}
+{"type": "pass", "data": {"moveNumber": 42}}
+{"type": "resign", "data": {}}
+{"type": "clock", "data": {"black": 542, "white": 600}}
+```
+
+All clients (local and remote) receive the same broadcasts from the host.
+
+### Clock Sync
+
+The host is authoritative for time. Clients receive periodic `clock` messages. On move receipt, host broadcasts updated clock state.
+
+For blitz games, clients should display server time, not local calculations.
+
+## Game Completion
+
+When the game ends, host publishes result via ActivityPub:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "actor": "https://server-a.example/users/alice",
+  "object": {
+    "type": "Note",
+    "id": "https://server-a.example/games/xyz789/result",
+    "content": "Game finished! @alice (B) defeated @bob@server-b.example (W) by resignation.",
+    "inReplyTo": "https://server-a.example/games/xyz789",
+    "attachment": {
+      "type": "BikGameResult",
+      "winner": "https://server-a.example/users/alice",
+      "result": "B+R",
+      "sgf": "https://server-a.example/games/xyz789.sgf"
+    }
+  }
+}
+```
+
+This appears as a post on ActivityPub, linkable and viewable by anyone.
+
+## Discovery
+
+### WebFinger
+
+Servers must implement WebFinger for actor discovery:
+
+```
+GET /.well-known/webfinger?resource=acct:alice@server-a.example
+```
+
+Returns:
+```json
+{
+  "subject": "acct:alice@server-a.example",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://server-a.example/users/alice"
+    }
+  ]
+}
+```
+
+### Server Keys
+
+For token verification, servers expose public keys at a well-known endpoint:
+
+```
+GET /.well-known/bik/keys
+```
+
+Returns JWK set for signature verification.
+
+## Security Considerations
+
+- All endpoints MUST use HTTPS
+- Tokens MUST have short expiry (recommend: 5 minutes)
+- Servers SHOULD rate-limit incoming federation requests
+- Hosts MUST validate that move submitters are game participants
+- Servers SHOULD implement HTTP Signatures for server-to-server requests (per ActivityPub spec)
+
+## Future Extensions
+
+- **Spectator federation**: Allow remote servers to subscribe to game updates
+- **Rating exchange**: Share rating information between trusted servers
+- **Tournament support**: Coordinate multi-game events across servers

--- a/justfile
+++ b/justfile
@@ -13,7 +13,8 @@ install:
 
 # Run BIK E2E test (two servers, two databases, full federation flow)
 e2e:
-	docker compose -f bik/e2e/docker-compose.yml run --rm test; \
+	docker compose -f bik/e2e/docker-compose.yml down -v --remove-orphans
+	docker compose -f bik/e2e/docker-compose.yml run --rm --build test; \
 	docker compose -f bik/e2e/docker-compose.yml down -v
 
 # Run server and client in split tmux session with hot reload

--- a/justfile
+++ b/justfile
@@ -11,6 +11,11 @@ install:
 	cd server && go mod download
 	cd web_client && npm install
 
+# Run BIK E2E test (two servers, two databases, full federation flow)
+e2e:
+	docker compose -f bik/e2e/docker-compose.yml run --rm test; \
+	docker compose -f bik/e2e/docker-compose.yml down -v
+
 # Run server and client in split tmux session with hot reload
 run:
 	#!/usr/bin/env bash

--- a/server/bik/keys.go
+++ b/server/bik/keys.go
@@ -1,0 +1,111 @@
+package bik
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Keys holds the server's Ed25519 key pair for signing/verifying BIK tokens.
+type Keys struct {
+	Private ed25519.PrivateKey
+	Public  ed25519.PublicKey
+}
+
+// GenerateKeys creates a new Ed25519 key pair.
+func GenerateKeys() (*Keys, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return &Keys{Private: priv, Public: pub}, nil
+}
+
+// LoadOrGenerateKeys loads keys from a PEM string, or generates new ones if empty.
+func LoadOrGenerateKeys(pemStr string) (*Keys, error) {
+	if pemStr == "" {
+		return GenerateKeys()
+	}
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("bik: invalid PEM data")
+	}
+	if len(block.Bytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("bik: expected %d byte Ed25519 key, got %d", ed25519.PrivateKeySize, len(block.Bytes))
+	}
+	priv := ed25519.PrivateKey(block.Bytes)
+	return &Keys{Private: priv, Public: priv.Public().(ed25519.PublicKey)}, nil
+}
+
+// JWKSet returns the public key as a JWK set for the /.well-known/bik/keys endpoint.
+func (k *Keys) JWKSet() JWKSet {
+	return JWKSet{
+		Keys: []JWK{{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			X:   base64.RawURLEncoding.EncodeToString(k.Public),
+		}},
+	}
+}
+
+// SignToken creates a signed BIK token for a player joining a game.
+func (k *Keys) SignToken(player, gameURI string, ttl time.Duration) (string, error) {
+	payload := BikToken{
+		Player: player,
+		Game:   gameURI,
+		Exp:    time.Now().Add(ttl).Unix(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sig := ed25519.Sign(k.Private, data)
+
+	// Token format: base64url(payload).base64url(signature)
+	return base64.RawURLEncoding.EncodeToString(data) + "." +
+		base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// VerifyToken verifies a BIK token signed by the given public key.
+func VerifyToken(token string, pubKey ed25519.PublicKey) (*BikToken, error) {
+	dotIdx := findLastDot(token)
+	if dotIdx < 0 {
+		return nil, errors.New("bik: malformed token")
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(token[:dotIdx])
+	if err != nil {
+		return nil, fmt.Errorf("bik: decode payload: %w", err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(token[dotIdx+1:])
+	if err != nil {
+		return nil, fmt.Errorf("bik: decode signature: %w", err)
+	}
+
+	if !ed25519.Verify(pubKey, data, sig) {
+		return nil, errors.New("bik: invalid signature")
+	}
+
+	var t BikToken
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("bik: decode token: %w", err)
+	}
+	if time.Now().Unix() > t.Exp {
+		return nil, errors.New("bik: token expired")
+	}
+	return &t, nil
+}
+
+func findLastDot(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			return i
+		}
+	}
+	return -1
+}

--- a/server/bik/keys.go
+++ b/server/bik/keys.go
@@ -3,7 +3,9 @@ package bik
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -15,6 +17,12 @@ import (
 type Keys struct {
 	Private ed25519.PrivateKey
 	Public  ed25519.PublicKey
+	Kid     string // derived from public key: hex(sha256(pub)[:8])
+}
+
+func deriveKid(pub ed25519.PublicKey) string {
+	h := sha256.Sum256(pub)
+	return hex.EncodeToString(h[:8])
 }
 
 // GenerateKeys creates a new Ed25519 key pair.
@@ -23,7 +31,7 @@ func GenerateKeys() (*Keys, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Keys{Private: priv, Public: pub}, nil
+	return &Keys{Private: priv, Public: pub, Kid: deriveKid(pub)}, nil
 }
 
 // LoadOrGenerateKeys loads keys from a PEM string, or generates new ones if empty.
@@ -39,7 +47,8 @@ func LoadOrGenerateKeys(pemStr string) (*Keys, error) {
 		return nil, fmt.Errorf("bik: expected %d byte Ed25519 key, got %d", ed25519.PrivateKeySize, len(block.Bytes))
 	}
 	priv := ed25519.PrivateKey(block.Bytes)
-	return &Keys{Private: priv, Public: priv.Public().(ed25519.PublicKey)}, nil
+	pub := priv.Public().(ed25519.PublicKey)
+	return &Keys{Private: priv, Public: pub, Kid: deriveKid(pub)}, nil
 }
 
 // JWKSet returns the public key as a JWK set for the /.well-known/bik/keys endpoint.
@@ -48,6 +57,7 @@ func (k *Keys) JWKSet() JWKSet {
 		Keys: []JWK{{
 			Kty: "OKP",
 			Crv: "Ed25519",
+			Kid: k.Kid,
 			X:   base64.RawURLEncoding.EncodeToString(k.Public),
 		}},
 	}
@@ -56,6 +66,7 @@ func (k *Keys) JWKSet() JWKSet {
 // SignToken creates a signed BIK token for a player joining a game.
 func (k *Keys) SignToken(player, gameURI string, ttl time.Duration) (string, error) {
 	payload := BikToken{
+		Kid:    k.Kid,
 		Player: player,
 		Game:   gameURI,
 		Exp:    time.Now().Add(ttl).Unix(),

--- a/server/bik/types.go
+++ b/server/bik/types.go
@@ -1,0 +1,90 @@
+package bik
+
+import "time"
+
+const APContext = "https://www.w3.org/ns/activitystreams"
+
+// AP activity types
+
+type Activity struct {
+	Context string `json:"@context"`
+	Type    string `json:"type"`
+	Actor   string `json:"actor"`
+	Object  any    `json:"object"`
+}
+
+type NoteObject struct {
+	Type         string `json:"type"` // "Note"
+	ID           string `json:"id"`
+	AttributedTo string `json:"attributedTo,omitempty"`
+	Content      string `json:"content"`
+	InReplyTo    string `json:"inReplyTo,omitempty"`
+	Attachment   any    `json:"attachment,omitempty"`
+}
+
+// BIK-specific attachment types
+
+type TimeControl struct {
+	System     string  `json:"system"`               // byoyomi, fischer, absolute
+	MainTime   float64 `json:"mainTime"`             // seconds
+	Periods    int     `json:"periods,omitempty"`    // byoyomi
+	PeriodTime float64 `json:"periodTime,omitempty"` // byoyomi
+	Increment  float64 `json:"increment,omitempty"`  // fischer
+}
+
+type BikChallenge struct {
+	Type        string      `json:"type"` // "BikChallenge"
+	BoardSize   int         `json:"boardSize"`
+	TimeControl TimeControl `json:"timeControl"`
+	ColorPref   string      `json:"colorPreference"` // black, white, any
+	ExpiresAt   time.Time   `json:"expiresAt"`
+}
+
+type BikGame struct {
+	Type      string `json:"type"` // "BikGame"
+	ID        string `json:"id"`
+	Black     string `json:"black"`     // actor URI
+	White     string `json:"white"`     // actor URI
+	URL       string `json:"url"`       // human-readable game page
+	WebSocket string `json:"websocket"` // wss:// URL
+}
+
+type BikGameResult struct {
+	Type   string `json:"type"` // "BikGameResult"
+	Winner string `json:"winner"`
+	Result string `json:"result"` // SGF: B+R, W+3.5, etc.
+	SGF    string `json:"sgf,omitempty"`
+}
+
+// Token issued by a guest server to authenticate a remote player to the host WS
+
+type BikToken struct {
+	Player string `json:"player"` // @user@domain
+	Game   string `json:"game"`   // game URI on host
+	Exp    int64  `json:"exp"`    // unix timestamp
+}
+
+// WebFinger response
+
+type WebFingerResponse struct {
+	Subject string             `json:"subject"`
+	Links   []WebFingerLink    `json:"links"`
+}
+
+type WebFingerLink struct {
+	Rel  string `json:"rel"`
+	Type string `json:"type,omitempty"`
+	Href string `json:"href,omitempty"`
+}
+
+// JWK set for public key exposure
+
+type JWKSet struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWK struct {
+	Kty string `json:"kty"` // "OKP"
+	Crv string `json:"crv"` // "Ed25519"
+	X   string `json:"x"`   // base64url-encoded public key
+}

--- a/server/bik/types.go
+++ b/server/bik/types.go
@@ -67,8 +67,8 @@ type BikToken struct {
 // WebFinger response
 
 type WebFingerResponse struct {
-	Subject string             `json:"subject"`
-	Links   []WebFingerLink    `json:"links"`
+	Subject string          `json:"subject"`
+	Links   []WebFingerLink `json:"links"`
 }
 
 type WebFingerLink struct {

--- a/server/bik/types.go
+++ b/server/bik/types.go
@@ -36,16 +36,15 @@ type BikChallenge struct {
 	Type        string      `json:"type"` // "BikChallenge"
 	BoardSize   int         `json:"boardSize"`
 	TimeControl TimeControl `json:"timeControl"`
-	ColorPref   string      `json:"colorPreference"` // black, white, any
+	ColorAssignment string  `json:"colorAssignment"` // black, white, random
 	ExpiresAt   time.Time   `json:"expiresAt"`
 }
 
 type BikGame struct {
 	Type      string `json:"type"` // "BikGame"
-	ID        string `json:"id"`
+	ID        string `json:"id"`        // full game URI — canonical identifier and human-readable page
 	Black     string `json:"black"`     // actor URI
 	White     string `json:"white"`     // actor URI
-	URL       string `json:"url"`       // human-readable game page
 	WebSocket string `json:"websocket"` // wss:// URL
 }
 
@@ -59,7 +58,8 @@ type BikGameResult struct {
 // Token issued by a guest server to authenticate a remote player to the host WS
 
 type BikToken struct {
-	Player string `json:"player"` // @user@domain
+	Kid    string `json:"kid"`    // key ID used to sign this token
+	Player string `json:"player"` // actor URI of the player
 	Game   string `json:"game"`   // game URI on host
 	Exp    int64  `json:"exp"`    // unix timestamp
 }
@@ -86,5 +86,6 @@ type JWKSet struct {
 type JWK struct {
 	Kty string `json:"kty"` // "OKP"
 	Crv string `json:"crv"` // "Ed25519"
+	Kid string `json:"kid"` // key ID
 	X   string `json:"x"`   // base64url-encoded public key
 }

--- a/server/bik/types.go
+++ b/server/bik/types.go
@@ -33,15 +33,15 @@ type TimeControl struct {
 }
 
 type BikChallenge struct {
-	Type        string      `json:"type"` // "BikChallenge"
-	BoardSize   int         `json:"boardSize"`
-	TimeControl TimeControl `json:"timeControl"`
-	ColorAssignment string  `json:"colorAssignment"` // black, white, random
-	ExpiresAt   time.Time   `json:"expiresAt"`
+	Type            string      `json:"type"` // "BikChallenge"
+	BoardSize       int         `json:"boardSize"`
+	TimeControl     TimeControl `json:"timeControl"`
+	ColorAssignment string      `json:"colorAssignment"` // black, white, random
+	ExpiresAt       time.Time   `json:"expiresAt"`
 }
 
 type BikGame struct {
-	Type      string `json:"type"` // "BikGame"
+	Type      string `json:"type"`      // "BikGame"
 	ID        string `json:"id"`        // full game URI — canonical identifier and human-readable page
 	Black     string `json:"black"`     // actor URI
 	White     string `json:"white"`     // actor URI

--- a/server/bik/webfinger.go
+++ b/server/bik/webfinger.go
@@ -19,7 +19,7 @@ type KeyCache struct {
 }
 
 type keyCacheEntry struct {
-	key     ed25519.PublicKey
+	key       ed25519.PublicKey
 	fetchedAt time.Time
 }
 

--- a/server/bik/webfinger.go
+++ b/server/bik/webfinger.go
@@ -1,0 +1,122 @@
+package bik
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// KeyCache fetches and caches remote server public keys.
+type KeyCache struct {
+	mu      sync.RWMutex
+	entries map[string]keyCacheEntry
+	client  *http.Client
+}
+
+type keyCacheEntry struct {
+	key     ed25519.PublicKey
+	fetchedAt time.Time
+}
+
+const keyCacheTTL = 1 * time.Hour
+
+func NewKeyCache() *KeyCache {
+	return &KeyCache{
+		entries: make(map[string]keyCacheEntry),
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// FetchPublicKey returns the Ed25519 public key for a remote BIK server.
+func (c *KeyCache) FetchPublicKey(serverDomain string) (ed25519.PublicKey, error) {
+	c.mu.RLock()
+	entry, ok := c.entries[serverDomain]
+	c.mu.RUnlock()
+	if ok && time.Since(entry.fetchedAt) < keyCacheTTL {
+		return entry.key, nil
+	}
+
+	key, err := fetchRemoteKey(c.client, serverDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.entries[serverDomain] = keyCacheEntry{key: key, fetchedAt: time.Now()}
+	c.mu.Unlock()
+	return key, nil
+}
+
+func fetchRemoteKey(client *http.Client, serverDomain string) (ed25519.PublicKey, error) {
+	keysURL := fmt.Sprintf("https://%s/.well-known/bik/keys", serverDomain)
+	resp, err := client.Get(keysURL)
+	if err != nil {
+		return nil, fmt.Errorf("bik: fetch keys from %s: %w", serverDomain, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bik: keys endpoint returned %d for %s", resp.StatusCode, serverDomain)
+	}
+
+	var jwks JWKSet
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, fmt.Errorf("bik: decode JWK set: %w", err)
+	}
+
+	for _, jwk := range jwks.Keys {
+		if jwk.Kty == "OKP" && jwk.Crv == "Ed25519" {
+			raw, err := base64.RawURLEncoding.DecodeString(jwk.X)
+			if err != nil {
+				return nil, fmt.Errorf("bik: decode public key: %w", err)
+			}
+			return ed25519.PublicKey(raw), nil
+		}
+	}
+	return nil, fmt.Errorf("bik: no Ed25519 key found at %s", serverDomain)
+}
+
+// LookupActor resolves a @user@domain handle to an AP actor URI via WebFinger.
+func LookupActor(client *http.Client, handle string) (string, error) {
+	// Parse @user@domain
+	if len(handle) == 0 || handle[0] != '@' {
+		return "", fmt.Errorf("bik: invalid handle %q", handle)
+	}
+	rest := handle[1:]
+	atIdx := -1
+	for i, c := range rest {
+		if c == '@' {
+			atIdx = i
+			break
+		}
+	}
+	if atIdx < 0 {
+		return "", fmt.Errorf("bik: invalid handle %q", handle)
+	}
+	domain := rest[atIdx+1:]
+
+	wfURL := fmt.Sprintf("https://%s/.well-known/webfinger?resource=%s",
+		domain, url.QueryEscape("acct:"+rest))
+
+	resp, err := client.Get(wfURL)
+	if err != nil {
+		return "", fmt.Errorf("bik: webfinger for %s: %w", handle, err)
+	}
+	defer resp.Body.Close()
+
+	var wf WebFingerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&wf); err != nil {
+		return "", err
+	}
+	for _, link := range wf.Links {
+		if link.Rel == "self" && link.Type == "application/activity+json" {
+			return link.Href, nil
+		}
+	}
+	return "", fmt.Errorf("bik: no AP actor link found for %s", handle)
+}

--- a/server/bik/webfinger.go
+++ b/server/bik/webfinger.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// KeyCache fetches and caches remote server public keys.
+// KeyCache fetches and caches remote server public keys, keyed by kid.
 type KeyCache struct {
 	mu      sync.RWMutex
 	entries map[string]keyCacheEntry
@@ -19,7 +19,7 @@ type KeyCache struct {
 }
 
 type keyCacheEntry struct {
-	key       ed25519.PublicKey
+	keys      map[string]ed25519.PublicKey // kid → public key
 	fetchedAt time.Time
 }
 
@@ -32,27 +32,37 @@ func NewKeyCache() *KeyCache {
 	}
 }
 
-// FetchPublicKey returns the Ed25519 public key for a remote BIK server.
-func (c *KeyCache) FetchPublicKey(serverDomain string) (ed25519.PublicKey, error) {
+// FetchPublicKey returns the Ed25519 public key for a given kid on a remote BIK server.
+// If the kid is not in the cache, the key set is re-fetched before failing — the remote
+// server may have rotated keys since the last fetch.
+func (c *KeyCache) FetchPublicKey(serverDomain, kid string) (ed25519.PublicKey, error) {
 	c.mu.RLock()
 	entry, ok := c.entries[serverDomain]
 	c.mu.RUnlock()
 	if ok && time.Since(entry.fetchedAt) < keyCacheTTL {
-		return entry.key, nil
+		if key, found := entry.keys[kid]; found {
+			return key, nil
+		}
+		// kid not found — fall through to re-fetch (server may have rotated)
 	}
 
-	key, err := fetchRemoteKey(c.client, serverDomain)
+	keys, err := fetchRemoteKeys(c.client, serverDomain)
 	if err != nil {
 		return nil, err
 	}
 
 	c.mu.Lock()
-	c.entries[serverDomain] = keyCacheEntry{key: key, fetchedAt: time.Now()}
+	c.entries[serverDomain] = keyCacheEntry{keys: keys, fetchedAt: time.Now()}
 	c.mu.Unlock()
+
+	key, found := keys[kid]
+	if !found {
+		return nil, fmt.Errorf("bik: key %q not found at %s", kid, serverDomain)
+	}
 	return key, nil
 }
 
-func fetchRemoteKey(client *http.Client, serverDomain string) (ed25519.PublicKey, error) {
+func fetchRemoteKeys(client *http.Client, serverDomain string) (map[string]ed25519.PublicKey, error) {
 	// Try https first (production), fall back to http (development/e2e)
 	var (
 		resp *http.Response
@@ -79,16 +89,21 @@ func fetchRemoteKey(client *http.Client, serverDomain string) (ed25519.PublicKey
 		return nil, fmt.Errorf("bik: decode JWK set: %w", err)
 	}
 
+	keys := make(map[string]ed25519.PublicKey)
 	for _, jwk := range jwks.Keys {
-		if jwk.Kty == "OKP" && jwk.Crv == "Ed25519" {
-			raw, err := base64.RawURLEncoding.DecodeString(jwk.X)
-			if err != nil {
-				return nil, fmt.Errorf("bik: decode public key: %w", err)
-			}
-			return ed25519.PublicKey(raw), nil
+		if jwk.Kty != "OKP" || jwk.Crv != "Ed25519" {
+			continue
 		}
+		raw, err := base64.RawURLEncoding.DecodeString(jwk.X)
+		if err != nil {
+			return nil, fmt.Errorf("bik: decode public key %q: %w", jwk.Kid, err)
+		}
+		keys[jwk.Kid] = ed25519.PublicKey(raw)
 	}
-	return nil, fmt.Errorf("bik: no Ed25519 key found at %s", serverDomain)
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("bik: no Ed25519 keys found at %s", serverDomain)
+	}
+	return keys, nil
 }
 
 // LookupActor resolves a @user@domain handle to an AP actor URI via WebFinger.

--- a/server/bik/webfinger.go
+++ b/server/bik/webfinger.go
@@ -53,8 +53,18 @@ func (c *KeyCache) FetchPublicKey(serverDomain string) (ed25519.PublicKey, error
 }
 
 func fetchRemoteKey(client *http.Client, serverDomain string) (ed25519.PublicKey, error) {
-	keysURL := fmt.Sprintf("https://%s/.well-known/bik/keys", serverDomain)
-	resp, err := client.Get(keysURL)
+	// Try https first (production), fall back to http (development/e2e)
+	var (
+		resp *http.Response
+		err  error
+	)
+	for _, scheme := range []string{"https", "http"} {
+		keysURL := fmt.Sprintf("%s://%s/.well-known/bik/keys", scheme, serverDomain)
+		resp, err = client.Get(keysURL)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("bik: fetch keys from %s: %w", serverDomain, err)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Config struct {
-	DatabaseURL    string
-	Port           string
-	JWTSecret      string
-	Environment    string
-	BaseURL        string // e.g. https://frogs.cafe — used for actor URIs and AP activities
-	BIKPrivateKey  string // PEM-encoded Ed25519 private key for signing BIK tokens
+	DatabaseURL   string
+	Port          string
+	JWTSecret     string
+	Environment   string
+	BaseURL       string // e.g. https://frogs.cafe — used for actor URIs and AP activities
+	BIKPrivateKey string // PEM-encoded Ed25519 private key for signing BIK tokens
 }
 
 func Load() *Config {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -6,18 +6,22 @@ import (
 )
 
 type Config struct {
-	DatabaseURL string
-	Port        string
-	JWTSecret   string
-	Environment string
+	DatabaseURL    string
+	Port           string
+	JWTSecret      string
+	Environment    string
+	BaseURL        string // e.g. https://frogs.cafe — used for actor URIs and AP activities
+	BIKPrivateKey  string // PEM-encoded Ed25519 private key for signing BIK tokens
 }
 
 func Load() *Config {
 	cfg := &Config{
-		DatabaseURL: getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/frogs_cafe?sslmode=disable"),
-		Port:        getEnv("PORT", "8080"),
-		JWTSecret:   getEnv("JWT_SECRET", "your-secret-key-change-in-production"),
-		Environment: getEnv("ENVIRONMENT", "development"),
+		DatabaseURL:   getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/frogs_cafe?sslmode=disable"),
+		Port:          getEnv("PORT", "8080"),
+		JWTSecret:     getEnv("JWT_SECRET", "your-secret-key-change-in-production"),
+		Environment:   getEnv("ENVIRONMENT", "development"),
+		BaseURL:       getEnv("BASE_URL", "http://localhost:8080"),
+		BIKPrivateKey: getEnv("BIK_PRIVATE_KEY", ""),
 	}
 
 	log.Printf("Configuration loaded - running in %s mode", cfg.Environment)

--- a/server/database/migrations/000007_add_bik.down.sql
+++ b/server/database/migrations/000007_add_bik.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE games
+    DROP COLUMN IF EXISTS black_actor_uri,
+    DROP COLUMN IF EXISTS white_actor_uri,
+    DROP COLUMN IF EXISTS bik_challenge_uri;
+
+DROP TABLE IF EXISTS bik_challenges;

--- a/server/database/migrations/000007_add_bik.up.sql
+++ b/server/database/migrations/000007_add_bik.up.sql
@@ -1,0 +1,18 @@
+-- BIK challenges created by local players
+CREATE TABLE IF NOT EXISTS bik_challenges (
+    id          SERIAL PRIMARY KEY,
+    creator_id  INTEGER NOT NULL REFERENCES players(id),
+    uri         TEXT NOT NULL UNIQUE,
+    board_size  INTEGER NOT NULL DEFAULT 19,
+    time_control JSONB NOT NULL,
+    color_pref  VARCHAR(10) NOT NULL DEFAULT 'any',
+    status      VARCHAR(20) NOT NULL DEFAULT 'open', -- open, accepted, cancelled
+    expires_at  TIMESTAMP NOT NULL,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Allow games to have remote (federated) players alongside local ones
+ALTER TABLE games
+    ADD COLUMN IF NOT EXISTS black_actor_uri TEXT,
+    ADD COLUMN IF NOT EXISTS white_actor_uri TEXT,
+    ADD COLUMN IF NOT EXISTS bik_challenge_uri TEXT;

--- a/server/database/migrations/000007_add_bik.up.sql
+++ b/server/database/migrations/000007_add_bik.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS bik_challenges (
     uri         TEXT NOT NULL UNIQUE,
     board_size  INTEGER NOT NULL DEFAULT 19,
     time_control JSONB NOT NULL,
-    color_pref  VARCHAR(10) NOT NULL DEFAULT 'any',
+    color_assignment VARCHAR(10) NOT NULL DEFAULT 'random',
     status      VARCHAR(20) NOT NULL DEFAULT 'open', -- open, accepted, cancelled
     expires_at  TIMESTAMP NOT NULL,
     created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/server/database/migrations/000008_moves_actor_uri.down.sql
+++ b/server/database/migrations/000008_moves_actor_uri.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE moves
+    ALTER COLUMN player_id SET NOT NULL,
+    DROP COLUMN IF EXISTS actor_uri;

--- a/server/database/migrations/000008_moves_actor_uri.up.sql
+++ b/server/database/migrations/000008_moves_actor_uri.up.sql
@@ -1,0 +1,4 @@
+-- Allow moves to be made by remote (federated) players who have no local player record
+ALTER TABLE moves
+    ALTER COLUMN player_id DROP NOT NULL,
+    ADD COLUMN IF NOT EXISTS actor_uri TEXT;

--- a/server/handlers/bik.go
+++ b/server/handlers/bik.go
@@ -1,0 +1,293 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"frogs_cafe/bik"
+	"frogs_cafe/middleware"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// WellKnownWebFinger handles GET /.well-known/webfinger
+func (h *Handler) WellKnownWebFinger(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get("resource")
+	// Expect: acct:username@domain
+	if !strings.HasPrefix(resource, "acct:") {
+		http.Error(w, "unsupported resource type", http.StatusBadRequest)
+		return
+	}
+	acct := strings.TrimPrefix(resource, "acct:")
+	atIdx := strings.LastIndex(acct, "@")
+	if atIdx < 0 {
+		http.Error(w, "invalid acct", http.StatusBadRequest)
+		return
+	}
+	username := acct[:atIdx]
+
+	var id int
+	err := h.db.QueryRow("SELECT id FROM players WHERE username = $1", username).Scan(&id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	resp := bik.WebFingerResponse{
+		Subject: resource,
+		Links: []bik.WebFingerLink{{
+			Rel:  "self",
+			Type: "application/activity+json",
+			Href: fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, username),
+		}},
+	}
+	w.Header().Set("Content-Type", "application/jrd+json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// WellKnownBIKKeys handles GET /.well-known/bik/keys
+func (h *Handler) WellKnownBIKKeys(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(h.bikKeys.JWKSet())
+}
+
+// BIKInbox handles POST /bik/inbox — receives AP activities from remote servers
+func (h *Handler) BIKInbox(w http.ResponseWriter, r *http.Request) {
+	var activity bik.Activity
+	if err := json.NewDecoder(r.Body).Decode(&activity); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	switch activity.Type {
+	case "Accept":
+		h.handleChallengeAccept(w, r, activity)
+	default:
+		http.Error(w, "unsupported activity type", http.StatusNotImplemented)
+	}
+}
+
+func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, activity bik.Activity) {
+	challengeURI, ok := activity.Object.(string)
+	if !ok {
+		http.Error(w, "object must be a challenge URI string", http.StatusBadRequest)
+		return
+	}
+
+	// Load the challenge
+	var (
+		challengeID int
+		creatorID   int
+		boardSize   int
+		timeCtrlRaw []byte
+		status      string
+		expiresAt   time.Time
+	)
+	err := h.db.QueryRow(`
+		SELECT id, creator_id, board_size, time_control, status, expires_at
+		FROM bik_challenges WHERE uri = $1
+	`, challengeURI).Scan(&challengeID, &creatorID, &boardSize, &timeCtrlRaw, &status, &expiresAt)
+	if err != nil {
+		http.Error(w, "challenge not found", http.StatusNotFound)
+		return
+	}
+	if status != "open" {
+		http.Error(w, "challenge no longer open", http.StatusConflict)
+		return
+	}
+	if time.Now().After(expiresAt) {
+		http.Error(w, "challenge expired", http.StatusGone)
+		return
+	}
+
+	// Look up the host player's username
+	var creatorUsername string
+	h.db.QueryRow("SELECT username FROM players WHERE id = $1", creatorID).Scan(&creatorUsername)
+
+	// Assign colors: creator gets black for now (TODO: respect colorPref)
+	blackActor := fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, creatorUsername)
+	whiteActor := activity.Actor
+
+	// Create the game
+	gameID := fmt.Sprintf("%d", time.Now().UnixNano()) // simple unique ID
+	var dbGameID int
+	err = h.db.QueryRow(`
+		INSERT INTO games (black_player_id, board_size, status, creator_id, black_actor_uri, white_actor_uri, bik_challenge_uri)
+		VALUES ($1, $2, 'active', $1, $3, $4, $5)
+		RETURNING id
+	`, creatorID, boardSize, blackActor, whiteActor, challengeURI).Scan(&dbGameID)
+	if err != nil {
+		http.Error(w, "failed to create game", http.StatusInternalServerError)
+		return
+	}
+	gameID = fmt.Sprintf("%d", dbGameID)
+
+	// Mark challenge as accepted
+	h.db.Exec("UPDATE bik_challenges SET status = 'accepted' WHERE id = $1", challengeID)
+
+	// Build response: CreateGame activity
+	gameURI := fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
+	wsURL := fmt.Sprintf("%s/ws/games/%s", strings.Replace(h.cfg.BaseURL, "http", "ws", 1), gameID)
+	gameActivity := bik.Activity{
+		Context: bik.APContext,
+		Type:    "Create",
+		Actor:   blackActor,
+		Object: bik.NoteObject{
+			Type:      "Note",
+			ID:        gameURI,
+			Content:   fmt.Sprintf("Game started! Watch at %s", gameURI),
+			InReplyTo: challengeURI,
+			Attachment: bik.BikGame{
+				Type:      "BikGame",
+				ID:        gameID,
+				Black:     blackActor,
+				White:     whiteActor,
+				URL:       gameURI,
+				WebSocket: wsURL,
+			},
+		},
+	}
+
+	// Also broadcast Undo for the challenge so followers know it's taken
+	go h.broadcastUndoChallenge(challengeURI, blackActor)
+
+	w.Header().Set("Content-Type", "application/activity+json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(gameActivity)
+}
+
+func (h *Handler) broadcastUndoChallenge(challengeURI, actor string) {
+	// TODO: deliver Undo activity to followers
+	// For now just log — full AP delivery is a future extension
+	_ = challengeURI
+	_ = actor
+}
+
+// CreateBIKChallenge handles POST /api/v1/bik/challenges
+func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
+	playerID, _ := middleware.GetPlayerID(r)
+
+	var req struct {
+		BoardSize   int             `json:"boardSize"`
+		TimeControl bik.TimeControl `json:"timeControl"`
+		ColorPref   string          `json:"colorPreference"`
+		ExpiresIn   int             `json:"expiresIn"` // seconds
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.BoardSize == 0 {
+		req.BoardSize = 19
+	}
+	if req.ExpiresIn == 0 {
+		req.ExpiresIn = 3600 // 1 hour default
+	}
+	if req.ColorPref == "" {
+		req.ColorPref = "any"
+	}
+
+	var username string
+	h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username)
+
+	challengeID := fmt.Sprintf("%d", time.Now().UnixNano())
+	challengeURI := fmt.Sprintf("%s/challenges/%s", h.cfg.BaseURL, challengeID)
+	expiresAt := time.Now().Add(time.Duration(req.ExpiresIn) * time.Second)
+
+	timeCtrlJSON, _ := json.Marshal(req.TimeControl)
+	_, err := h.db.Exec(`
+		INSERT INTO bik_challenges (creator_id, uri, board_size, time_control, color_pref, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, playerID, challengeURI, req.BoardSize, timeCtrlJSON, req.ColorPref, expiresAt)
+	if err != nil {
+		http.Error(w, "failed to create challenge", http.StatusInternalServerError)
+		return
+	}
+
+	actorURI := fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, username)
+	content := fmt.Sprintf("Looking for a game! %dx%d", req.BoardSize, req.BoardSize)
+
+	activity := bik.Activity{
+		Context: bik.APContext,
+		Type:    "Create",
+		Actor:   actorURI,
+		Object: bik.NoteObject{
+			Type:         "Note",
+			ID:           challengeURI,
+			AttributedTo: actorURI,
+			Content:      content,
+			Attachment: bik.BikChallenge{
+				Type:        "BikChallenge",
+				BoardSize:   req.BoardSize,
+				TimeControl: req.TimeControl,
+				ColorPref:   req.ColorPref,
+				ExpiresAt:   expiresAt,
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/activity+json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(activity)
+}
+
+// ListBIKChallenges handles GET /api/v1/bik/challenges
+func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.db.Query(`
+		SELECT c.uri, p.username, c.board_size, c.time_control, c.color_pref, c.expires_at
+		FROM bik_challenges c
+		JOIN players p ON p.id = c.creator_id
+		WHERE c.status = 'open' AND c.expires_at > NOW()
+		ORDER BY c.created_at DESC
+	`)
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	type challengeItem struct {
+		URI       string          `json:"uri"`
+		Creator   string          `json:"creator"`
+		BoardSize int             `json:"boardSize"`
+		TimeCtrl  json.RawMessage `json:"timeControl"`
+		ColorPref string          `json:"colorPreference"`
+		ExpiresAt time.Time       `json:"expiresAt"`
+	}
+
+	items := []challengeItem{}
+	for rows.Next() {
+		var item challengeItem
+		var timeCtrlRaw []byte
+		rows.Scan(&item.URI, &item.Creator, &item.BoardSize, &timeCtrlRaw, &item.ColorPref, &item.ExpiresAt)
+		item.TimeCtrl = json.RawMessage(timeCtrlRaw)
+		items = append(items, item)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}
+
+// GetBIKToken handles POST /api/v1/bik/token — issues a signed token for a remote game
+func (h *Handler) GetBIKToken(w http.ResponseWriter, r *http.Request) {
+	playerID, _ := middleware.GetPlayerID(r)
+	gameID := chi.URLParam(r, "gameID")
+
+	var username string
+	h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username)
+
+	gameURI := fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
+	handle := fmt.Sprintf("@%s@%s", username, strings.TrimPrefix(strings.TrimPrefix(h.cfg.BaseURL, "https://"), "http://"))
+
+	token, err := h.bikKeys.SignToken(handle, gameURI, 5*time.Minute)
+	if err != nil {
+		http.Error(w, "failed to sign token", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"token": token})
+}

--- a/server/handlers/bik.go
+++ b/server/handlers/bik.go
@@ -115,7 +115,7 @@ func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	// Assign colors: creator gets black for now (TODO: respect colorPref)
+	// Assign colors: creator gets black for now (TODO: respect colorAssignment)
 	blackActor := fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, creatorUsername)
 	whiteActor := activity.Actor
 
@@ -151,10 +151,9 @@ func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, 
 			InReplyTo: challengeURI,
 			Attachment: bik.BikGame{
 				Type:      "BikGame",
-				ID:        gameID,
+				ID:        gameURI,
 				Black:     blackActor,
 				White:     whiteActor,
-				URL:       gameURI,
 				WebSocket: wsURL,
 			},
 		},
@@ -184,7 +183,7 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		BoardSize   int             `json:"boardSize"`
 		TimeControl bik.TimeControl `json:"timeControl"`
-		ColorPref   string          `json:"colorPreference"`
+		ColorAssignment string      `json:"colorAssignment"`
 		ExpiresIn   int             `json:"expiresIn"` // seconds
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -197,8 +196,8 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 	if req.ExpiresIn == 0 {
 		req.ExpiresIn = 3600 // 1 hour default
 	}
-	if req.ColorPref == "" {
-		req.ColorPref = "any"
+	if req.ColorAssignment == "" {
+		req.ColorAssignment = "random"
 	}
 
 	var username string
@@ -213,9 +212,9 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 
 	timeCtrlJSON, _ := json.Marshal(req.TimeControl)
 	_, err := h.db.Exec(`
-		INSERT INTO bik_challenges (creator_id, uri, board_size, time_control, color_pref, expires_at)
+		INSERT INTO bik_challenges (creator_id, uri, board_size, time_control, color_assignment, expires_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
-	`, playerID, challengeURI, req.BoardSize, timeCtrlJSON, req.ColorPref, expiresAt)
+	`, playerID, challengeURI, req.BoardSize, timeCtrlJSON, req.ColorAssignment, expiresAt)
 	if err != nil {
 		http.Error(w, "failed to create challenge", http.StatusInternalServerError)
 		return
@@ -237,7 +236,7 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 				Type:        "BikChallenge",
 				BoardSize:   req.BoardSize,
 				TimeControl: req.TimeControl,
-				ColorPref:   req.ColorPref,
+				ColorAssignment: req.ColorAssignment,
 				ExpiresAt:   expiresAt,
 			},
 		},
@@ -253,7 +252,7 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 // ListBIKChallenges handles GET /api/v1/bik/challenges
 func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Query(`
-		SELECT c.uri, p.username, c.board_size, c.time_control, c.color_pref, c.expires_at
+		SELECT c.uri, p.username, c.board_size, c.time_control, c.color_assignment, c.expires_at
 		FROM bik_challenges c
 		JOIN players p ON p.id = c.creator_id
 		WHERE c.status = 'open' AND c.expires_at > NOW()
@@ -270,7 +269,7 @@ func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
 		Creator   string          `json:"creator"`
 		BoardSize int             `json:"boardSize"`
 		TimeCtrl  json.RawMessage `json:"timeControl"`
-		ColorPref string          `json:"colorPreference"`
+		ColorAssignment string    `json:"colorAssignment"`
 		ExpiresAt time.Time       `json:"expiresAt"`
 	}
 
@@ -278,7 +277,7 @@ func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var item challengeItem
 		var timeCtrlRaw []byte
-		if err := rows.Scan(&item.URI, &item.Creator, &item.BoardSize, &timeCtrlRaw, &item.ColorPref, &item.ExpiresAt); err != nil {
+		if err := rows.Scan(&item.URI, &item.Creator, &item.BoardSize, &timeCtrlRaw, &item.ColorAssignment, &item.ExpiresAt); err != nil {
 			http.Error(w, "db error", http.StatusInternalServerError)
 			return
 		}

--- a/server/handlers/bik.go
+++ b/server/handlers/bik.go
@@ -279,10 +279,15 @@ func (h *Handler) GetBIKToken(w http.ResponseWriter, r *http.Request) {
 	var username string
 	h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username)
 
-	gameURI := fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
-	handle := fmt.Sprintf("@%s@%s", username, strings.TrimPrefix(strings.TrimPrefix(h.cfg.BaseURL, "https://"), "http://"))
+	// Allow caller to provide the full game URI for cross-server games.
+	// Falls back to this server's own game URI if not specified.
+	gameURI := r.URL.Query().Get("gameURI")
+	if gameURI == "" {
+		gameURI = fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
+	}
+	actorURI := fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, username)
 
-	token, err := h.bikKeys.SignToken(handle, gameURI, 5*time.Minute)
+	token, err := h.bikKeys.SignToken(actorURI, gameURI, 5*time.Minute)
 	if err != nil {
 		http.Error(w, "failed to sign token", http.StatusInternalServerError)
 		return

--- a/server/handlers/bik.go
+++ b/server/handlers/bik.go
@@ -181,10 +181,10 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 	playerID, _ := middleware.GetPlayerID(r)
 
 	var req struct {
-		BoardSize   int             `json:"boardSize"`
-		TimeControl bik.TimeControl `json:"timeControl"`
-		ColorAssignment string      `json:"colorAssignment"`
-		ExpiresIn   int             `json:"expiresIn"` // seconds
+		BoardSize       int             `json:"boardSize"`
+		TimeControl     bik.TimeControl `json:"timeControl"`
+		ColorAssignment string          `json:"colorAssignment"`
+		ExpiresIn       int             `json:"expiresIn"` // seconds
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
@@ -233,11 +233,11 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 			AttributedTo: actorURI,
 			Content:      content,
 			Attachment: bik.BikChallenge{
-				Type:        "BikChallenge",
-				BoardSize:   req.BoardSize,
-				TimeControl: req.TimeControl,
+				Type:            "BikChallenge",
+				BoardSize:       req.BoardSize,
+				TimeControl:     req.TimeControl,
 				ColorAssignment: req.ColorAssignment,
-				ExpiresAt:   expiresAt,
+				ExpiresAt:       expiresAt,
 			},
 		},
 	}
@@ -265,12 +265,12 @@ func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	type challengeItem struct {
-		URI       string          `json:"uri"`
-		Creator   string          `json:"creator"`
-		BoardSize int             `json:"boardSize"`
-		TimeCtrl  json.RawMessage `json:"timeControl"`
-		ColorAssignment string    `json:"colorAssignment"`
-		ExpiresAt time.Time       `json:"expiresAt"`
+		URI             string          `json:"uri"`
+		Creator         string          `json:"creator"`
+		BoardSize       int             `json:"boardSize"`
+		TimeCtrl        json.RawMessage `json:"timeControl"`
+		ColorAssignment string          `json:"colorAssignment"`
+		ExpiresAt       time.Time       `json:"expiresAt"`
 	}
 
 	items := []challengeItem{}

--- a/server/handlers/bik.go
+++ b/server/handlers/bik.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -45,13 +46,17 @@ func (h *Handler) WellKnownWebFinger(w http.ResponseWriter, r *http.Request) {
 		}},
 	}
 	w.Header().Set("Content-Type", "application/jrd+json")
-	json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("WellKnownWebFinger: encode: %v", err)
+	}
 }
 
 // WellKnownBIKKeys handles GET /.well-known/bik/keys
 func (h *Handler) WellKnownBIKKeys(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(h.bikKeys.JWKSet())
+	if err := json.NewEncoder(w).Encode(h.bikKeys.JWKSet()); err != nil {
+		log.Printf("WellKnownBIKKeys: encode: %v", err)
+	}
 }
 
 // BIKInbox handles POST /bik/inbox — receives AP activities from remote servers
@@ -105,14 +110,16 @@ func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, 
 
 	// Look up the host player's username
 	var creatorUsername string
-	h.db.QueryRow("SELECT username FROM players WHERE id = $1", creatorID).Scan(&creatorUsername)
+	if err := h.db.QueryRow("SELECT username FROM players WHERE id = $1", creatorID).Scan(&creatorUsername); err != nil {
+		http.Error(w, "failed to look up creator", http.StatusInternalServerError)
+		return
+	}
 
 	// Assign colors: creator gets black for now (TODO: respect colorPref)
 	blackActor := fmt.Sprintf("%s/users/%s", h.cfg.BaseURL, creatorUsername)
 	whiteActor := activity.Actor
 
 	// Create the game
-	gameID := fmt.Sprintf("%d", time.Now().UnixNano()) // simple unique ID
 	var dbGameID int
 	err = h.db.QueryRow(`
 		INSERT INTO games (black_player_id, board_size, status, creator_id, black_actor_uri, white_actor_uri, bik_challenge_uri)
@@ -123,10 +130,12 @@ func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, 
 		http.Error(w, "failed to create game", http.StatusInternalServerError)
 		return
 	}
-	gameID = fmt.Sprintf("%d", dbGameID)
+	gameID := fmt.Sprintf("%d", dbGameID)
 
 	// Mark challenge as accepted
-	h.db.Exec("UPDATE bik_challenges SET status = 'accepted' WHERE id = $1", challengeID)
+	if _, err := h.db.Exec("UPDATE bik_challenges SET status = 'accepted' WHERE id = $1", challengeID); err != nil {
+		log.Printf("handleChallengeAccept: mark accepted: %v", err)
+	}
 
 	// Build response: CreateGame activity
 	gameURI := fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
@@ -156,7 +165,9 @@ func (h *Handler) handleChallengeAccept(w http.ResponseWriter, r *http.Request, 
 
 	w.Header().Set("Content-Type", "application/activity+json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(gameActivity)
+	if err := json.NewEncoder(w).Encode(gameActivity); err != nil {
+		log.Printf("handleChallengeAccept: encode: %v", err)
+	}
 }
 
 func (h *Handler) broadcastUndoChallenge(challengeURI, actor string) {
@@ -191,7 +202,10 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var username string
-	h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username)
+	if err := h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username); err != nil {
+		http.Error(w, "failed to look up player", http.StatusInternalServerError)
+		return
+	}
 
 	challengeID := fmt.Sprintf("%d", time.Now().UnixNano())
 	challengeURI := fmt.Sprintf("%s/challenges/%s", h.cfg.BaseURL, challengeID)
@@ -231,7 +245,9 @@ func (h *Handler) CreateBIKChallenge(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/activity+json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(activity)
+	if err := json.NewEncoder(w).Encode(activity); err != nil {
+		log.Printf("CreateBIKChallenge: encode: %v", err)
+	}
 }
 
 // ListBIKChallenges handles GET /api/v1/bik/challenges
@@ -262,13 +278,18 @@ func (h *Handler) ListBIKChallenges(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var item challengeItem
 		var timeCtrlRaw []byte
-		rows.Scan(&item.URI, &item.Creator, &item.BoardSize, &timeCtrlRaw, &item.ColorPref, &item.ExpiresAt)
+		if err := rows.Scan(&item.URI, &item.Creator, &item.BoardSize, &timeCtrlRaw, &item.ColorPref, &item.ExpiresAt); err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
 		item.TimeCtrl = json.RawMessage(timeCtrlRaw)
 		items = append(items, item)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(items)
+	if err := json.NewEncoder(w).Encode(items); err != nil {
+		log.Printf("ListBIKChallenges: encode: %v", err)
+	}
 }
 
 // GetBIKToken handles POST /api/v1/bik/token — issues a signed token for a remote game
@@ -277,7 +298,10 @@ func (h *Handler) GetBIKToken(w http.ResponseWriter, r *http.Request) {
 	gameID := chi.URLParam(r, "gameID")
 
 	var username string
-	h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username)
+	if err := h.db.QueryRow("SELECT username FROM players WHERE id = $1", playerID).Scan(&username); err != nil {
+		http.Error(w, "failed to look up player", http.StatusInternalServerError)
+		return
+	}
 
 	// Allow caller to provide the full game URI for cross-server games.
 	// Falls back to this server's own game URI if not specified.
@@ -294,5 +318,7 @@ func (h *Handler) GetBIKToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"token": token})
+	if err := json.NewEncoder(w).Encode(map[string]string{"token": token}); err != nil {
+		log.Printf("GetBIKToken: encode: %v", err)
+	}
 }

--- a/server/handlers/games.go
+++ b/server/handlers/games.go
@@ -38,14 +38,28 @@ func (h *Handler) isGameParticipant(gameIDStr string, playerID int, actorURI str
 	return count > 0, err
 }
 
-func (h *Handler) SaveMove(gameIDStr string, playerID int, actorURI string, data map[string]interface{}) error {
+// SaveMove saves a move to the database and returns the move number.
+func (h *Handler) SaveMove(gameIDStr string, playerID int, actorURI string, data map[string]interface{}) (int, error) {
 	gameID, err := strconv.Atoi(gameIDStr)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	x := int(data["x"].(float64))
-	y := int(data["y"].(float64))
+	// Support BIK coordinate format: pos: [col, row]
+	// Fall back to legacy x/y fields for backwards compatibility
+	var x, y int
+	if pos, ok := data["pos"]; ok {
+		if pos == nil {
+			// pass — store as -1,-1
+			x, y = -1, -1
+		} else if arr, ok := pos.([]interface{}); ok && len(arr) == 2 {
+			x = int(arr[0].(float64))
+			y = int(arr[1].(float64))
+		}
+	} else {
+		x = int(data["x"].(float64))
+		y = int(data["y"].(float64))
+	}
 
 	var moveNumber int
 	err = h.db.QueryRow(
@@ -53,7 +67,7 @@ func (h *Handler) SaveMove(gameIDStr string, playerID int, actorURI string, data
 		gameID,
 	).Scan(&moveNumber)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if actorURI != "" {
@@ -68,7 +82,60 @@ func (h *Handler) SaveMove(gameIDStr string, playerID int, actorURI string, data
 			gameID, playerID, moveNumber, x, y,
 		)
 	}
-	return err
+	return moveNumber, err
+}
+
+func (h *Handler) handleResign(c *Client) {
+	gameID := c.gameID
+
+	// Determine winner (the other participant)
+	var blackPlayerID *int
+	var whitePlayerID *int
+	var blackActorURI, whiteActorURI string
+	h.db.QueryRow(`
+		SELECT black_player_id, white_player_id,
+		       COALESCE(black_actor_uri, ''), COALESCE(white_actor_uri, '')
+		FROM games WHERE id = $1
+	`, gameID).Scan(&blackPlayerID, &whitePlayerID, &blackActorURI, &whiteActorURI)
+
+	// Figure out who resigned and who won
+	var winnerColor string
+	resignerIsBlack := (c.playerID > 0 && blackPlayerID != nil && *blackPlayerID == c.playerID) ||
+		(c.actorURI != "" && blackActorURI == c.actorURI)
+	if resignerIsBlack {
+		winnerColor = "white"
+	} else {
+		winnerColor = "black"
+	}
+
+	result := string(winnerColor[0]-32) + "+R" // "W+R" or "B+R"
+
+	// Mark game finished
+	h.db.Exec("UPDATE games SET status = 'finished' WHERE id = $1", gameID)
+
+	// Broadcast game_over
+	gameOver := map[string]interface{}{
+		"type": "game_over",
+		"data": map[string]interface{}{
+			"result":     result,
+			"winner":     winnerColor,
+			"scoreBlack": nil,
+			"scoreWhite": nil,
+		},
+	}
+	if b, err := json.Marshal(gameOver); err == nil {
+		// Send to all clients watching this game
+		hub.mutex.RLock()
+		for client := range hub.clients {
+			if client.gameID == gameID {
+				select {
+				case client.send <- b:
+				default:
+				}
+			}
+		}
+		hub.mutex.RUnlock()
+	}
 }
 
 func (h *Handler) ListGames(w http.ResponseWriter, r *http.Request) {

--- a/server/handlers/games.go
+++ b/server/handlers/games.go
@@ -111,7 +111,9 @@ func (h *Handler) handleResign(c *Client) {
 	result := string(winnerColor[0]-32) + "+R" // "W+R" or "B+R"
 
 	// Mark game finished
-	h.db.Exec("UPDATE games SET status = 'finished' WHERE id = $1", gameID)
+	if _, err := h.db.Exec("UPDATE games SET status = 'finished' WHERE id = $1", gameID); err != nil {
+		log.Printf("handleResign: mark finished: %v", err)
+	}
 
 	// Broadcast game_over
 	gameOver := map[string]interface{}{

--- a/server/handlers/games.go
+++ b/server/handlers/games.go
@@ -92,11 +92,14 @@ func (h *Handler) handleResign(c *Client) {
 	var blackPlayerID *int
 	var whitePlayerID *int
 	var blackActorURI, whiteActorURI string
-	h.db.QueryRow(`
+	if err := h.db.QueryRow(`
 		SELECT black_player_id, white_player_id,
 		       COALESCE(black_actor_uri, ''), COALESCE(white_actor_uri, '')
 		FROM games WHERE id = $1
-	`, gameID).Scan(&blackPlayerID, &whitePlayerID, &blackActorURI, &whiteActorURI)
+	`, gameID).Scan(&blackPlayerID, &whitePlayerID, &blackActorURI, &whiteActorURI); err != nil {
+		log.Printf("error fetching game players: %v", err)
+		return
+	}
 
 	// Figure out who resigned and who won
 	var winnerColor string

--- a/server/handlers/games.go
+++ b/server/handlers/games.go
@@ -13,7 +13,32 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func (h *Handler) SaveMove(gameIDStr string, playerID int, data map[string]interface{}) error {
+// isGameParticipant returns true if the given player (by local ID or actor URI) is a participant in the game.
+func (h *Handler) isGameParticipant(gameIDStr string, playerID int, actorURI string) (bool, error) {
+	gameID, err := strconv.Atoi(gameIDStr)
+	if err != nil {
+		return false, err
+	}
+	var count int
+	if actorURI != "" {
+		// Remote player: check actor URI against federated columns
+		err = h.db.QueryRow(`
+			SELECT COUNT(*) FROM games
+			WHERE id = $1 AND status = 'active'
+			AND (black_actor_uri = $2 OR white_actor_uri = $2)
+		`, gameID, actorURI).Scan(&count)
+	} else {
+		// Local player: check player ID against local columns
+		err = h.db.QueryRow(`
+			SELECT COUNT(*) FROM games
+			WHERE id = $1 AND status = 'active'
+			AND (black_player_id = $2 OR white_player_id = $2)
+		`, gameID, playerID).Scan(&count)
+	}
+	return count > 0, err
+}
+
+func (h *Handler) SaveMove(gameIDStr string, playerID int, actorURI string, data map[string]interface{}) error {
 	gameID, err := strconv.Atoi(gameIDStr)
 	if err != nil {
 		return err
@@ -22,7 +47,6 @@ func (h *Handler) SaveMove(gameIDStr string, playerID int, data map[string]inter
 	x := int(data["x"].(float64))
 	y := int(data["y"].(float64))
 
-	// Get the current move number
 	var moveNumber int
 	err = h.db.QueryRow(
 		"SELECT COALESCE(MAX(move_number), 0) + 1 FROM moves WHERE game_id = $1",
@@ -32,11 +56,18 @@ func (h *Handler) SaveMove(gameIDStr string, playerID int, data map[string]inter
 		return err
 	}
 
-	// Insert the move
-	_, err = h.db.Exec(
-		"INSERT INTO moves (game_id, player_id, move_number, x, y) VALUES ($1, $2, $3, $4, $5)",
-		gameID, playerID, moveNumber, x, y,
-	)
+	if actorURI != "" {
+		// Remote player: store actor_uri, leave player_id null
+		_, err = h.db.Exec(
+			"INSERT INTO moves (game_id, actor_uri, move_number, x, y) VALUES ($1, $2, $3, $4, $5)",
+			gameID, actorURI, moveNumber, x, y,
+		)
+	} else {
+		_, err = h.db.Exec(
+			"INSERT INTO moves (game_id, player_id, move_number, x, y) VALUES ($1, $2, $3, $4, $5)",
+			gameID, playerID, moveNumber, x, y,
+		)
+	}
 	return err
 }
 

--- a/server/handlers/handler.go
+++ b/server/handlers/handler.go
@@ -1,15 +1,29 @@
 package handlers
 
 import (
+	"frogs_cafe/bik"
+	"frogs_cafe/config"
 	"frogs_cafe/database"
 )
 
 type Handler struct {
-	db *database.DB
+	db       *database.DB
+	cfg      *config.Config
+	bikKeys  *bik.Keys
+	keyCache *bik.KeyCache
 }
 
-func New(db *database.DB) *Handler {
-	h := &Handler{db: db}
+func New(db *database.DB, cfg *config.Config) (*Handler, error) {
+	keys, err := bik.LoadOrGenerateKeys(cfg.BIKPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	h := &Handler{
+		db:       db,
+		cfg:      cfg,
+		bikKeys:  keys,
+		keyCache: bik.NewKeyCache(),
+	}
 	InitHub(h)
-	return h
+	return h, nil
 }

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -27,12 +27,12 @@ var upgrader = websocket.Upgrader{
 }
 
 type Client struct {
-	conn      *websocket.Conn
-	send      chan []byte
-	gameID    string
-	userID    string
-	playerID  int    // local player ID; -1 for remote (BIK) players
-	actorURI  string // set for remote players authenticated via BIK token
+	conn     *websocket.Conn
+	send     chan []byte
+	gameID   string
+	userID   string
+	playerID int    // local player ID; -1 for remote (BIK) players
+	actorURI string // set for remote players authenticated via BIK token
 }
 
 type Hub struct {

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -289,15 +289,28 @@ func (c *Client) readPump() {
 
 		// Handle move type messages
 		if msgType, ok := msg["type"].(string); ok && msgType == "move" {
-			// Only authenticated players can make moves (local: playerID > 0, remote: playerID == -1)
-			if c.playerID == 0 {
+			// Guests cannot make moves
+			if c.playerID == 0 && c.actorURI == "" {
 				log.Printf("Guest attempted to make a move - rejected")
 				continue
 			}
 
+			// Verify the client is actually a participant in this game
+			ok, err := hub.handler.isGameParticipant(c.gameID, c.playerID, c.actorURI)
+			if err != nil || !ok {
+				log.Printf("Move rejected: %s is not a participant in game %s", c.userID, c.gameID)
+				reject := map[string]interface{}{
+					"type": "move_rejected",
+					"data": map[string]string{"reason": "not_your_turn"},
+				}
+				if b, err := json.Marshal(reject); err == nil {
+					c.send <- b
+				}
+				continue
+			}
+
 			if data, ok := msg["data"].(map[string]interface{}); ok {
-				// Use authenticated playerID from JWT, not from message
-				if err := hub.handler.SaveMove(c.gameID, c.playerID, data); err != nil {
+				if err := hub.handler.SaveMove(c.gameID, c.playerID, c.actorURI, data); err != nil {
 					log.Printf("Error saving move: %v", err)
 					continue
 				}

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -173,8 +174,62 @@ func (h *Handler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	hub.register <- client
 
+	// Send current game state immediately on connect
+	if gameID != "" {
+		go h.sendGameState(client, gameID)
+	}
+
 	go client.writePump()
 	go client.readPump()
+}
+
+func (h *Handler) sendGameState(client *Client, gameIDStr string) {
+	// Fetch moves
+	rows, err := h.db.Query(
+		"SELECT x, y FROM moves WHERE game_id = $1 ORDER BY move_number ASC",
+		gameIDStr,
+	)
+	if err != nil {
+		log.Printf("sendGameState: query moves: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type pos [2]int
+	moves := []interface{}{}
+	for rows.Next() {
+		var x, y int
+		rows.Scan(&x, &y)
+		moves = append(moves, pos{x, y})
+	}
+
+	// Fetch game phase
+	var status string
+	h.db.QueryRow("SELECT status FROM games WHERE id = $1", gameIDStr).Scan(&status)
+	phase := status // active/finished map directly; waiting → active for simplicity
+
+	nextToPlay := "black"
+	if len(moves)%2 == 1 {
+		nextToPlay = "white"
+	}
+
+	msg := map[string]interface{}{
+		"type": "game_state",
+		"data": map[string]interface{}{
+			"moves":      moves,
+			"phase":      phase,
+			"nextToPlay": nextToPlay,
+			"clock": map[string]interface{}{
+				"system":      "absolute",
+				"black":       300,
+				"white":       300,
+				"activeColor": nextToPlay,
+			},
+		},
+	}
+	if b, err := json.Marshal(msg); err == nil {
+		client.send <- b
+	}
 }
 
 // verifyBIKToken parses and verifies a BIK token issued by a remote server.
@@ -193,12 +248,12 @@ func (h *Handler) verifyBIKToken(token, gameID string) (*bik.BikToken, error) {
 		return nil, fmt.Errorf("unmarshal BIK token: %w", err)
 	}
 
-	// Extract server domain from player handle (@user@domain)
-	parts := strings.Split(strings.TrimPrefix(t.Player, "@"), "@")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid player handle in BIK token: %s", t.Player)
+	// Extract server domain from actor URI (e.g. "https://server-b.example/users/bob" → "server-b.example")
+	playerURL, err := url.Parse(t.Player)
+	if err != nil || playerURL.Host == "" {
+		return nil, fmt.Errorf("invalid player URI in BIK token: %s", t.Player)
 	}
-	domain := parts[1]
+	domain := playerURL.Host
 
 	// Fetch remote server's public key (cached)
 	pubKey, err := h.keyCache.FetchPublicKey(domain)
@@ -310,26 +365,60 @@ func (c *Client) readPump() {
 			}
 
 			if data, ok := msg["data"].(map[string]interface{}); ok {
-				if err := hub.handler.SaveMove(c.gameID, c.playerID, c.actorURI, data); err != nil {
+				moveNumber, err := hub.handler.SaveMove(c.gameID, c.playerID, c.actorURI, data)
+				if err != nil {
 					log.Printf("Error saving move: %v", err)
 					continue
 				}
 
-				// Add the authenticated player_id to the data before broadcasting
-				data["player_id"] = float64(c.playerID) // JSON numbers are float64
-				msg["data"] = data
+				// Determine color from move number: odd = black, even = white
+				color := "black"
+				nextToPlay := "white"
+				if moveNumber%2 == 0 {
+					color = "white"
+					nextToPlay = "black"
+				}
 
-				// Re-marshal the updated message
-				updatedMessage, err := json.Marshal(msg)
+				// Build move_played broadcast per BIK spec
+				movePlayed := map[string]interface{}{
+					"type": "move_played",
+					"data": map[string]interface{}{
+						"pos":        data["pos"],
+						"moveNumber": moveNumber,
+						"color":      color,
+						"captures":   []interface{}{},
+						"nextToPlay": nextToPlay,
+						"clock": map[string]interface{}{
+							"system":      "absolute",
+							"black":       300,
+							"white":       300,
+							"activeColor": nextToPlay,
+						},
+					},
+				}
+
+				updatedMessage, err := json.Marshal(movePlayed)
 				if err != nil {
-					log.Printf("Error marshaling updated message: %v", err)
+					log.Printf("Error marshaling move_played: %v", err)
 					continue
 				}
 
-				// Broadcast the updated message to all clients in the same game
 				hub.broadcast <- updatedMessage
 				continue
 			}
+		}
+
+		// Handle resign
+		if msgType, ok := msg["type"].(string); ok && msgType == "resign" {
+			if c.playerID == 0 && c.actorURI == "" {
+				continue // guests can't resign
+			}
+			ok, _ := hub.handler.isGameParticipant(c.gameID, c.playerID, c.actorURI)
+			if !ok {
+				continue
+			}
+			hub.handler.handleResign(c)
+			continue
 		}
 
 		// For other message types, broadcast as-is

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -208,7 +208,9 @@ func (h *Handler) sendGameState(client *Client, gameIDStr string) {
 
 	// Fetch game phase
 	var status string
-	h.db.QueryRow("SELECT status FROM games WHERE id = $1", gameIDStr).Scan(&status)
+	if err := h.db.QueryRow("SELECT status FROM games WHERE id = $1", gameIDStr).Scan(&status); err != nil {
+		log.Printf("error fetching game status: %v", err)
+	}
 	phase := status // active/finished map directly; waiting → active for simplicity
 
 	nextToPlay := "black"

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -1,14 +1,18 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 
 	"frogs_cafe/auth"
+	"frogs_cafe/bik"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 )
 
@@ -22,11 +26,12 @@ var upgrader = websocket.Upgrader{
 }
 
 type Client struct {
-	conn     *websocket.Conn
-	send     chan []byte
-	gameID   string
-	userID   string
-	playerID int
+	conn      *websocket.Conn
+	send      chan []byte
+	gameID    string
+	userID    string
+	playerID  int    // local player ID; -1 for remote (BIK) players
+	actorURI  string // set for remote players authenticated via BIK token
 }
 
 type Hub struct {
@@ -110,7 +115,6 @@ func (h *Hub) run() {
 }
 
 func (h *Handler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
-	// Get token from query parameter or header
 	token := r.URL.Query().Get("token")
 	if token == "" {
 		authHeader := r.Header.Get("Authorization")
@@ -119,23 +123,36 @@ func (h *Handler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Token is now optional - guests can view without authentication
+	// Game ID from URL path (/ws/games/{gameID}) or query param (legacy)
+	gameID := chi.URLParam(r, "gameID")
+	if gameID == "" {
+		gameID = r.URL.Query().Get("game_id")
+	}
+
 	var playerID int
 	var username string
-	var err error
+	var actorURI string
 
 	if token != "" {
-		// Validate session token
+		// Try local session token first
+		var err error
 		playerID, username, err = auth.ValidateSession(h.db.DB, token)
 		if err != nil {
-			log.Printf("Token validation failed: %v", err)
-			// Continue as guest instead of returning error
-			playerID = 0
-			username = "guest"
+			// Try BIK token (remote player)
+			bikTok, bikErr := h.verifyBIKToken(token, gameID)
+			if bikErr != nil {
+				log.Printf("WS auth failed — session: %v; bik: %v", err, bikErr)
+				// Fall through as guest
+			} else {
+				actorURI = bikTok.Player
+				username = bikTok.Player
+				playerID = -1 // sentinel: remote player
+				log.Printf("Remote player authenticated via BIK token: %s", actorURI)
+			}
 		}
-	} else {
-		// Guest viewer
-		playerID = 0
+	}
+
+	if playerID == 0 && actorURI == "" {
 		username = "guest"
 	}
 
@@ -148,15 +165,60 @@ func (h *Handler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	client := &Client{
 		conn:     conn,
 		send:     make(chan []byte, 256),
-		gameID:   r.URL.Query().Get("game_id"),
+		gameID:   gameID,
 		userID:   username,
 		playerID: playerID,
+		actorURI: actorURI,
 	}
 
 	hub.register <- client
 
 	go client.writePump()
 	go client.readPump()
+}
+
+// verifyBIKToken parses and verifies a BIK token issued by a remote server.
+func (h *Handler) verifyBIKToken(token, gameID string) (*bik.BikToken, error) {
+	// Decode payload without verifying (to extract the player's server domain)
+	dotIdx := strings.LastIndex(token, ".")
+	if dotIdx < 0 {
+		return nil, fmt.Errorf("malformed BIK token")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(token[:dotIdx])
+	if err != nil {
+		return nil, fmt.Errorf("decode BIK token payload: %w", err)
+	}
+	var t bik.BikToken
+	if err := json.Unmarshal(payloadBytes, &t); err != nil {
+		return nil, fmt.Errorf("unmarshal BIK token: %w", err)
+	}
+
+	// Extract server domain from player handle (@user@domain)
+	parts := strings.Split(strings.TrimPrefix(t.Player, "@"), "@")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid player handle in BIK token: %s", t.Player)
+	}
+	domain := parts[1]
+
+	// Fetch remote server's public key (cached)
+	pubKey, err := h.keyCache.FetchPublicKey(domain)
+	if err != nil {
+		return nil, fmt.Errorf("fetch public key for %s: %w", domain, err)
+	}
+
+	// Verify signature and expiry
+	verified, err := bik.VerifyToken(token, pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Confirm the token is for this game
+	expectedGameURI := fmt.Sprintf("%s/games/%s", h.cfg.BaseURL, gameID)
+	if verified.Game != expectedGameURI {
+		return nil, fmt.Errorf("BIK token game mismatch: got %s, want %s", verified.Game, expectedGameURI)
+	}
+
+	return verified, nil
 }
 
 func (c *Client) readPump() {
@@ -227,7 +289,7 @@ func (c *Client) readPump() {
 
 		// Handle move type messages
 		if msgType, ok := msg["type"].(string); ok && msgType == "move" {
-			// Only authenticated players can make moves
+			// Only authenticated players can make moves (local: playerID > 0, remote: playerID == -1)
 			if c.playerID == 0 {
 				log.Printf("Guest attempted to make a move - rejected")
 				continue

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -258,10 +258,10 @@ func (h *Handler) verifyBIKToken(token, gameID string) (*bik.BikToken, error) {
 	}
 	domain := playerURL.Host
 
-	// Fetch remote server's public key (cached)
-	pubKey, err := h.keyCache.FetchPublicKey(domain)
+	// Fetch remote server's public key by kid (re-fetches on unknown kid)
+	pubKey, err := h.keyCache.FetchPublicKey(domain, t.Kid)
 	if err != nil {
-		return nil, fmt.Errorf("fetch public key for %s: %w", domain, err)
+		return nil, fmt.Errorf("fetch public key for %s kid %q: %w", domain, t.Kid, err)
 	}
 
 	// Verify signature and expiry

--- a/server/handlers/websocket.go
+++ b/server/handlers/websocket.go
@@ -199,7 +199,10 @@ func (h *Handler) sendGameState(client *Client, gameIDStr string) {
 	moves := []interface{}{}
 	for rows.Next() {
 		var x, y int
-		rows.Scan(&x, &y)
+		if err := rows.Scan(&x, &y); err != nil {
+			log.Printf("sendGameState: scan move: %v", err)
+			continue
+		}
 		moves = append(moves, pos{x, y})
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -84,10 +84,18 @@ func main() {
 	}))
 
 	// Initialize handlers
-	h := handlers.New(db)
+	h, err := handlers.New(db, cfg)
+	if err != nil {
+		log.Fatalf("Failed to initialize handlers: %v", err)
+	}
 
 	// Routes
 	r.Get("/health", h.HealthCheck)
+
+	// Federation endpoints
+	r.Get("/.well-known/webfinger", h.WellKnownWebFinger)
+	r.Get("/.well-known/bik/keys", h.WellKnownBIKKeys)
+	r.Post("/bik/inbox", h.BIKInbox)
 
 	// API routes
 	r.Route("/api/v1", func(r chi.Router) {
@@ -112,10 +120,19 @@ func main() {
 		r.Get("/players", h.ListPlayers)
 		r.Post("/players", h.CreatePlayer)
 		r.Get("/players/{playerID}", h.GetPlayer)
+
+		// BIK routes
+		r.Get("/bik/challenges", h.ListBIKChallenges)
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.RequireAuth(db.DB))
+			r.Post("/bik/challenges", h.CreateBIKChallenge)
+			r.Post("/bik/token/{gameID}", h.GetBIKToken)
+		})
 	})
 
 	// WebSocket route
 	r.Get("/ws", h.HandleWebSocket)
+	r.Get("/ws/games/{gameID}", h.HandleWebSocket)
 
 	// Serve static files from React build (production)
 	staticDir := "./static"


### PR DESCRIPTION
## Summary

BIK (Baduk InterKonnect) — a federation protocol for playing Go across servers.

- **Protocol spec** (`bik/spec/protocol.md`): identity via WebFinger/fediverse handles (`@user@domain`), ActivityPub for matchmaking (challenge create/accept/undo), WebSockets for low-latency gameplay, Ed25519-signed BIK tokens for cross-server auth
- **JSON schemas** (`bik/schema/`): AP activities, WebSocket client/server messages, common types (positions, clocks, results)
- **TypeScript library** (`bik/bik-js/`): typed WS client, AP activity builders, 13 passing unit/integration tests
- **Go server implementation**: WebFinger endpoint, JWK public key endpoint, AP inbox (Accept → game creation), BIK token signing/verification, WS auth for remote players, `move_played` broadcast per spec
- **E2E test** (`bik/e2e/`): two Docker-containerized servers, two databases — full federation flow from challenge to game over

## E2E flow

```
alice@server-a creates challenge
  → bob@server-b POSTs Accept to server-a's AP inbox
  → server-a creates game, returns CreateGame activity
  → bob requests BIK token from server-b (scoped to server-a's game)
  → both connect to server-a's WebSocket directly from the test (Node.js BikClient)
  → moves exchanged, server broadcasts move_played
  → bob resigns → both receive game_over (B+R)
```

## What the E2E does NOT cover (web client)

The E2E test uses `BikClient` in Node.js and bypasses the frogs.cafe web client entirely. Still needed on the UI side:

- Displaying a created BIK challenge with a shareable URI
- Notifying the local player when someone on a remote server accepts their challenge
- A flow for a frogs.cafe user to accept a *remote* challenge (paste URI, request BIK token, connect to a foreign WS URL)
- The game board UI working when the WebSocket points at an arbitrary host server

## Run it

```
just e2e        # full two-server Docker E2E
cd bik/bik-js && npm test   # 13 unit/integration tests
```